### PR TITLE
Solid Frame can now use unicode characters for drawing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set (MUNIN_SOURCE_FILES
     src/container.cpp
     src/filled_box.cpp
     src/framed_component.cpp
+    src/graphics.cpp
     src/grid_layout.cpp
     src/horizontal_strip_layout.cpp
     src/image.cpp
@@ -93,6 +94,7 @@ set (MUNIN_INCLUDE_FILES
     include/munin/container.hpp
     include/munin/filled_box.hpp
     include/munin/framed_component.hpp
+    include/munin/graphics.hpp
     include/munin/grid_layout.hpp
     include/munin/horizontal_strip_layout.hpp
     include/munin/image.hpp

--- a/include/munin/detail/unicode_glyphs.hpp
+++ b/include/munin/detail/unicode_glyphs.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <terminalpp/glyph.hpp>
+
+namespace munin { namespace detail { inline namespace unicode {
+
+// Some uncommon glyphs that are very useful.
+
+static constexpr terminalpp::glyph const single_lined_top_left_corner("\U0000250C");
+static constexpr terminalpp::glyph const single_lined_top_right_corner("\U00002510");
+static constexpr terminalpp::glyph const single_lined_bottom_left_corner("\U00002514");
+static constexpr terminalpp::glyph const single_lined_bottom_right_corner("\U00002518");
+
+static constexpr terminalpp::glyph const single_lined_rounded_top_left_corner("\U0000256D");
+static constexpr terminalpp::glyph const single_lined_rounded_top_right_corner("\U0000256E");
+static constexpr terminalpp::glyph const single_lined_rounded_bottom_left_corner("\U00002570");
+static constexpr terminalpp::glyph const single_lined_rounded_bottom_right_corner("\U0000256F");
+
+static constexpr terminalpp::glyph const single_lined_horizontal_beam("\U00002500");
+static constexpr terminalpp::glyph const single_lined_vertical_beam("\U00002502");
+static constexpr terminalpp::glyph const single_lined_top_tee("\U0000252C");
+static constexpr terminalpp::glyph const single_lined_left_tee("\U0000251C");
+static constexpr terminalpp::glyph const single_lined_bottom_tee("\U00002534");
+static constexpr terminalpp::glyph const single_lined_right_tee("\U00002524");
+static constexpr terminalpp::glyph const single_lined_cross("\U0000253C");
+
+// Double-lined box drawing
+static constexpr terminalpp::glyph const double_lined_top_left_corner("\U00002554");
+static constexpr terminalpp::glyph const double_lined_top_right_corner("\U00002557");
+static constexpr terminalpp::glyph const double_lined_bottom_left_corner("\U0000255A");
+static constexpr terminalpp::glyph const double_lined_bottom_right_corner("\U0000255D");
+static constexpr terminalpp::glyph const double_lined_horizontal_beam("\U00002550");
+static constexpr terminalpp::glyph const double_lined_vertical_beam("\U00002551");
+static constexpr terminalpp::glyph const double_lined_top_tee("\U00002566");
+static constexpr terminalpp::glyph const double_lined_left_tee("\U00002560");
+static constexpr terminalpp::glyph const double_lined_bottom_tee("\U00002569");
+static constexpr terminalpp::glyph const double_lined_right_tee("\U00002563");
+static constexpr terminalpp::glyph const double_lined_cross("\U0000256C");
+
+// Mix-lined box drawing.  v and h describe whether the single-line component
+// is horizontal or vertical
+static constexpr terminalpp::glyph const mix_lined_vright_tee("\U00002561");
+static constexpr terminalpp::glyph const mix_lined_hright_tee("\U00002562");
+static constexpr terminalpp::glyph const mix_lined_vtop_right_corner("\U00002555");
+static constexpr terminalpp::glyph const mix_lined_htop_right_corner("\U00002556");
+static constexpr terminalpp::glyph const mix_lined_vbottom_right_corner("\U0000255B");
+static constexpr terminalpp::glyph const mix_lined_hbottom_right_corner("\U0000255C");
+static constexpr terminalpp::glyph const mix_lined_vleft_tee("\U0000255E");
+static constexpr terminalpp::glyph const mix_lined_hleft_tee("\U0000255F");
+static constexpr terminalpp::glyph const mix_lined_vbottom_tee("\U00002567");
+static constexpr terminalpp::glyph const mix_lined_hbottom_tee("\U00002568");
+static constexpr terminalpp::glyph const mix_lined_vtop_tee("\U00002564");
+static constexpr terminalpp::glyph const mix_lined_htop_tee("\U00002565");
+static constexpr terminalpp::glyph const mix_lined_vbottom_left_corner("\U00002559");
+static constexpr terminalpp::glyph const mix_lined_hbottom_left_corner("\U0000255A");
+static constexpr terminalpp::glyph const mix_lined_vtop_left_corner("\U00002552");
+static constexpr terminalpp::glyph const mix_lined_htop_left_corner("\U00002553");
+static constexpr terminalpp::glyph const mix_lined_hcross("\U0000256B");
+static constexpr terminalpp::glyph const mix_lined_vcross("\U0000256A");
+
+// Other drawing characters.
+static constexpr terminalpp::glyph const left_guillemet("\U000000AB");
+static constexpr terminalpp::glyph const right_guillemet("\U000000BB");
+static constexpr terminalpp::glyph const light_cross("\U00002573");
+static constexpr terminalpp::glyph const down_pointing_triangle("\U000025BE");
+
+}}}

--- a/include/munin/graphics.hpp
+++ b/include/munin/graphics.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "munin/export.hpp"
+
+namespace munin {
+
+//* =========================================================================
+/// \brief A class that describes the desirable graphical attributes of
+/// the rendering device. 
+//* =========================================================================
+class MUNIN_EXPORT graphics
+{
+public :
+    //* =====================================================================
+    /// \brief Destructor
+    //* =====================================================================
+    virtual ~graphics() = default;
+
+    //* =====================================================================
+    /// \brief Returns true iff unicode should be used for drawing
+    /// characters
+    //* =====================================================================
+    virtual bool supports_unicode() const = 0;
+};
+
+//* =========================================================================
+/// \brief Retrieves the current graphics object.
+//* =========================================================================
+MUNIN_EXPORT
+graphics& get_graphics();
+
+//* =========================================================================
+/// \brief Sets the current graphics object.
+///
+/// Setting an null value will install the default graphics object.
+/// Note: a graphics object is associated with a particular thread.  This
+/// allows independent components with different graphics objects to be 
+/// processed concurrently.
+///
+/// It is the caller's responsibility to ensure that gr is lives until either
+/// this thread is terminated, or set_graphics is called again on this 
+/// thread.
+//* =========================================================================
+MUNIN_EXPORT
+void set_graphics(graphics* gr);
+
+}

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1,0 +1,54 @@
+#include "munin/graphics.hpp"
+#include <cassert>
+
+namespace munin {
+namespace {
+
+// ==========================================================================
+// Default Graphics structure.  Provides a baseline set of capabilities
+// that can be rendered universally.
+// ==========================================================================
+class default_graphics : public graphics
+{
+public :
+    bool supports_unicode() const override
+    {
+        return false;
+    }
+};
+
+// ==========================================================================
+// A default graphics object.  This also acts as a null object for when
+// no specific graphics object is set.
+// ==========================================================================
+default_graphics default_gr;
+
+// ==========================================================================
+// A graphics object that is local to the current thread.  This allows
+// graphics objects to be set for independent components that are being 
+// handled concurrently.
+// ==========================================================================
+thread_local graphics *current_thread_graphics = &default_gr;
+
+}
+
+// ==========================================================================
+// GET_GRAPHICS
+// ==========================================================================
+graphics &get_graphics()
+{
+    assert(current_thread_graphics != nullptr);
+    return *current_thread_graphics;
+}
+
+// ==========================================================================
+// SET_GRAPHICS
+// ==========================================================================
+void set_graphics(graphics *gr)
+{
+    current_thread_graphics = gr == nullptr
+                            ? &default_gr
+                            : gr;
+}
+
+}

--- a/src/solid_frame.cpp
+++ b/src/solid_frame.cpp
@@ -1,9 +1,78 @@
-#include <munin/solid_frame.hpp>
-#include <munin/compass_layout.hpp>
-#include <munin/filled_box.hpp>
-#include <munin/view.hpp>
+#include "munin/solid_frame.hpp"
+#include "munin/detail/unicode_glyphs.hpp"
+#include "munin/compass_layout.hpp"
+#include "munin/filled_box.hpp"
+#include "munin/graphics.hpp"
+#include "munin/view.hpp"
 
 namespace munin {
+namespace {
+
+constexpr terminalpp::glyph const default_corner_glyph          = '+';
+constexpr terminalpp::glyph const default_horizontal_beam_glyph = '-';
+constexpr terminalpp::glyph const default_vertical_beam_glyph   = '|';
+    
+// ==========================================================================
+// TOP_LEFT_CORNER_GLYPH
+// ==========================================================================
+terminalpp::glyph top_left_corner_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_top_left_corner
+         : default_corner_glyph;
+}
+
+// ==========================================================================
+// TOP_RIGHT_CORNER_GLYPH
+// ==========================================================================
+terminalpp::glyph top_right_corner_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_top_right_corner
+         : default_corner_glyph;
+}
+
+// ==========================================================================
+// BOTTOM_LEFT_CORNER_GLYPH
+// ==========================================================================
+terminalpp::glyph bottom_left_corner_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_bottom_left_corner
+         : default_corner_glyph;
+}
+
+// ==========================================================================
+// BOTTOM_RIGHT_CORNER_GLYPH
+// ==========================================================================
+terminalpp::glyph bottom_right_corner_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_bottom_right_corner
+         : default_corner_glyph;
+}
+
+// ==========================================================================
+// HORIZONTAL_BEAM_GLYPH
+// ==========================================================================
+terminalpp::glyph horizontal_beam_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_horizontal_beam
+         : default_horizontal_beam_glyph;
+}
+
+// ==========================================================================
+// VERTICAL_BEAM_GLYPH
+// ==========================================================================
+terminalpp::glyph vertical_beam_glyph()
+{
+    return get_graphics().supports_unicode()
+         ? detail::double_lined_vertical_beam
+         : default_vertical_beam_glyph;
+}
+
+}
 
 struct solid_frame::impl
 {
@@ -13,26 +82,22 @@ struct solid_frame::impl
         terminalpp::colour(),
         terminalpp::ansi::graphics::intensity::bold};
 
-    static constexpr terminalpp::glyph corner_glyph          = '+';
-    static constexpr terminalpp::glyph horizontal_beam_glyph = '-';
-    static constexpr terminalpp::glyph vertical_beam_glyph   = '|';
-    
     std::shared_ptr<munin::filled_box> top_left = 
-        munin::make_fill({corner_glyph, lowlight_attribute});
+        munin::make_fill({top_left_corner_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> top_centre = 
-        munin::make_fill({horizontal_beam_glyph, lowlight_attribute});
+        munin::make_fill({horizontal_beam_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> top_right = 
-        munin::make_fill({corner_glyph, lowlight_attribute});
+        munin::make_fill({top_right_corner_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> centre_left = 
-        munin::make_fill({vertical_beam_glyph, lowlight_attribute});
+        munin::make_fill({vertical_beam_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> centre_right = 
-        munin::make_fill({vertical_beam_glyph, lowlight_attribute});
+        munin::make_fill({vertical_beam_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> bottom_left = 
-        munin::make_fill({corner_glyph, lowlight_attribute});
+        munin::make_fill({bottom_left_corner_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> bottom_centre = 
-        munin::make_fill({horizontal_beam_glyph, lowlight_attribute});
+        munin::make_fill({horizontal_beam_glyph(), lowlight_attribute});
     std::shared_ptr<munin::filled_box> bottom_right = 
-        munin::make_fill({corner_glyph, lowlight_attribute});
+        munin::make_fill({bottom_right_corner_glyph(), lowlight_attribute});
     
     bool is_highlighted = false;
     
@@ -40,21 +105,20 @@ struct solid_frame::impl
     {
         auto const &attr = is_highlighted ? highlight_attribute : lowlight_attribute;
         
-        top_left->set_fill({corner_glyph, attr});
-        top_centre->set_fill({horizontal_beam_glyph, attr});
-        top_right->set_fill({corner_glyph, attr});
-        centre_left->set_fill({vertical_beam_glyph, attr});
-        centre_right->set_fill({vertical_beam_glyph, attr});
-        bottom_left->set_fill({corner_glyph, attr});
-        bottom_centre->set_fill({horizontal_beam_glyph, attr});
-        bottom_right->set_fill({corner_glyph, attr});
+        top_left->set_fill({top_left_corner_glyph(), attr});
+        top_centre->set_fill({horizontal_beam_glyph(), attr});
+        top_right->set_fill({top_right_corner_glyph(), attr});
+        centre_left->set_fill({vertical_beam_glyph(), attr});
+        centre_right->set_fill({vertical_beam_glyph(), attr});
+        bottom_left->set_fill({bottom_left_corner_glyph(), attr});
+        bottom_centre->set_fill({horizontal_beam_glyph(), attr});
+        bottom_right->set_fill({bottom_right_corner_glyph(), attr});
     }
 };
 
-constexpr terminalpp::glyph solid_frame::impl::corner_glyph;
-constexpr terminalpp::glyph solid_frame::impl::horizontal_beam_glyph;
-constexpr terminalpp::glyph solid_frame::impl::vertical_beam_glyph;
-
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
 solid_frame::solid_frame()
   : pimpl_(std::make_shared<impl>())
 {
@@ -81,10 +145,16 @@ solid_frame::solid_frame()
     add_component(east_beam, compass_layout::heading::east);
 }
 
+// ==========================================================================
+// DESTRUCTOR
+// ==========================================================================
 solid_frame::~solid_frame()
 {
 }
 
+// ==========================================================================
+// SET_HIGHLIGHT_ATTRIBUTE
+// ==========================================================================
 void solid_frame::set_highlight_attribute(
     terminalpp::attribute const &highlight_attribute)
 {
@@ -92,6 +162,9 @@ void solid_frame::set_highlight_attribute(
     pimpl_->set_fills();
 }
 
+// ==========================================================================
+// SET_LOWLIGHT_ATTRIBUTE
+// ==========================================================================
 void solid_frame::set_lowlight_attribute(
     terminalpp::attribute const &lowlight_attribute)
 {
@@ -99,12 +172,18 @@ void solid_frame::set_lowlight_attribute(
     pimpl_->set_fills();
 }
 
+// ==========================================================================
+// SET_HIGHLIGHT
+// ==========================================================================
 void solid_frame::set_highlight(bool highlight)
 {
     pimpl_->is_highlighted = highlight;
     pimpl_->set_fills();
 }
 
+// ==========================================================================
+// MAKE_SOLID_FRAME
+// ==========================================================================
 std::shared_ptr<solid_frame> make_solid_frame()
 {
     return std::make_shared<solid_frame>();

--- a/test/include/mock/graphics.hpp
+++ b/test/include/mock/graphics.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <munin/graphics.hpp>
+#include <gmock/gmock.h>
+
+class mock_graphics : public munin::graphics
+{
+public :
+    //* =====================================================================
+    /// \brief Returns true iff unicode should be used for drawing
+    /// characters
+    //* =====================================================================
+    MOCK_CONST_METHOD0(supports_unicode, bool ());
+};

--- a/test/src/solid_frame/solid_frame_test.cpp
+++ b/test/src/solid_frame/solid_frame_test.cpp
@@ -1,7 +1,12 @@
+#include "mock/graphics.hpp"
 #include <munin/solid_frame.hpp>
 #include <terminalpp/canvas.hpp>
 #include <terminalpp/canvas_view.hpp>
+#include <terminalpp/string.hpp>
 #include <gtest/gtest.h>
+
+using testing::NiceMock;
+using testing::Return;
 
 TEST(a_solid_frame, is_a_component)
 {
@@ -185,3 +190,59 @@ TEST(a_solid_frame, remains_unhighlighted_when_setting_the_highlight_attribute)
     ASSERT_EQ(terminalpp::element('-', lowlight_attribute), cv[2][3]);
     ASSERT_EQ(terminalpp::element('+', lowlight_attribute), cv[3][3]);
 }
+
+class a_solid_frame_with_unicode_graphics : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ON_CALL(mock_gr_, supports_unicode())
+            .WillByDefault(Return(true));
+
+        munin::set_graphics(&mock_gr_);
+    }
+
+    void TearDown() override
+    {
+        munin::set_graphics(nullptr);
+    }
+
+    NiceMock<mock_graphics> mock_gr_;  
+};
+
+TEST_F(a_solid_frame_with_unicode_graphics, draws_a_border_with_box_drawing_glyphs)
+{
+    munin::solid_frame frame;
+    frame.set_size({4, 4});
+    
+    terminalpp::canvas canvas({4, 4});
+    terminalpp::canvas_view cv(canvas);
+    frame.draw(cv, {{}, {4, 4}});
+
+    using namespace terminalpp::literals;
+    static terminalpp::element const top_left_corner     = "\\U2554"_ets[0];
+    static terminalpp::element const top_right_corner    = "\\U2557"_ets[0];
+    static terminalpp::element const bottom_left_corner  = "\\U255A"_ets[0];
+    static terminalpp::element const bottom_right_corner = "\\U255D"_ets[0];
+    static terminalpp::element const horizontal_beam     = "\\U2550"_ets[0];
+    static terminalpp::element const vertical_beam       = "\\U2551"_ets[0];
+
+    ASSERT_EQ(top_left_corner,     terminalpp::element(cv[0][0]));
+    ASSERT_EQ(horizontal_beam,     cv[1][0]);
+    ASSERT_EQ(horizontal_beam,     cv[2][0]);
+    ASSERT_EQ(top_right_corner,    cv[3][0]);
+    ASSERT_EQ(vertical_beam,       cv[0][1]);
+    ASSERT_EQ(vertical_beam,       cv[0][2]);
+    ASSERT_EQ(vertical_beam,       cv[3][2]);
+    ASSERT_EQ(vertical_beam,       cv[3][1]);
+    ASSERT_EQ(bottom_left_corner,  cv[0][3]);
+    ASSERT_EQ(horizontal_beam,     cv[1][3]);
+    ASSERT_EQ(horizontal_beam,     cv[2][3]);
+    ASSERT_EQ(bottom_right_corner, cv[3][3]);
+}
+
+/*
+TEST(a_solid_frame, draws_a_border)
+{
+}
+*/


### PR DESCRIPTION
Closes #106

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/110)
<!-- Reviewable:end -->