### PR TITLE
Render surface#113

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set (MUNIN_SOURCE_FILES
     src/image.cpp
     src/layout.cpp
     src/null_layout.cpp
+    src/render_surface.cpp
     src/solid_frame.cpp
     src/vertical_strip_layout.cpp
     src/window.cpp
@@ -101,6 +102,7 @@ set (MUNIN_INCLUDE_FILES
     include/munin/layout.hpp
     include/munin/null_layout.hpp
     include/munin/rectangle.hpp
+    include/munin/render_surface.hpp
     include/munin/solid_frame.hpp
     include/munin/vertical_strip_layout.hpp
     include/munin/window.hpp
@@ -187,6 +189,8 @@ if (GTEST_FOUND)
         test/src/image/image_redraw_test.cpp
         test/src/image/new_image_test.cpp
         test/src/null_layout/null_layout_test.cpp
+        test/src/render_surface/render_surface_capabilities_test.cpp
+        test/src/render_surface/render_surface_test.cpp
         test/src/solid_frame/solid_frame_test.cpp
         test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
         test/src/window/window_json_test.cpp

--- a/include/munin/brush.hpp
+++ b/include/munin/brush.hpp
@@ -65,12 +65,12 @@ protected :
     /// in order to draw onto the passed canvas.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas in which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void do_draw(
-        terminalpp::canvas_view &cvs, 
+        render_surface &surface, 
         rectangle const &region) const override;
 
     //* =====================================================================

--- a/include/munin/component.hpp
+++ b/include/munin/component.hpp
@@ -2,7 +2,6 @@
 
 #include "munin/export.hpp"
 #include "munin/rectangle.hpp"
-#include <terminalpp/canvas_view.hpp>
 #include <terminalpp/extent.hpp>
 #include <terminalpp/point.hpp>
 #include <json.hpp>
@@ -12,6 +11,8 @@
 #include <vector>
 
 namespace munin {
+
+class render_surface;
 
 //* =========================================================================
 /// \brief An object capable of being drawn on a canvas.
@@ -118,12 +119,12 @@ public :
     //* =====================================================================
     /// \brief Draws the component.
     ///
-    /// \param cvs the canvas on which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void draw(
-        terminalpp::canvas_view &cvs
+        render_surface &surface
       , rectangle const &region) const;
 
     //* =====================================================================
@@ -299,12 +300,12 @@ protected :
     /// in order to draw onto the passed context.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas on which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     virtual void do_draw(
-        terminalpp::canvas_view &cvs,
+        render_surface &surface,
         rectangle const &region) const = 0;
 
     //* =====================================================================

--- a/include/munin/composite_component.hpp
+++ b/include/munin/composite_component.hpp
@@ -130,12 +130,12 @@ protected :
     /// in order to draw onto the passed context.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas on which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void do_draw(
-        terminalpp::canvas_view &cvs,
+        render_surface &surface,
         rectangle const &region) const override;
 
     //* =====================================================================

--- a/include/munin/container.hpp
+++ b/include/munin/container.hpp
@@ -147,12 +147,12 @@ private :
     /// in order to draw onto the passed canvas.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas in which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void do_draw(
-        terminalpp::canvas_view &cvs, 
+        render_surface &surface, 
         rectangle const &region) const override;
 
     //* =====================================================================

--- a/include/munin/detail/algorithm.hpp
+++ b/include/munin/detail/algorithm.hpp
@@ -53,13 +53,4 @@ std::vector<rectangle> clip_regions(
 //* =========================================================================
 std::vector<rectangle> prune_regions(std::vector<rectangle> regions);
 
-//* =========================================================================
-/// \brief Copies a region from one canvas to another.
-//* =========================================================================
-MUNIN_EXPORT
-void copy_region(
-    rectangle               const &region,
-    terminalpp::canvas      const &source,
-    terminalpp::canvas_view       &destination);
-
 }}

--- a/include/munin/filled_box.hpp
+++ b/include/munin/filled_box.hpp
@@ -50,12 +50,12 @@ protected :
     /// in order to draw onto the passed canvas.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas in which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void do_draw(
-        terminalpp::canvas_view &cvs, 
+        render_surface &surface,
         rectangle const &region) const override;
 
     //* =====================================================================

--- a/include/munin/image.hpp
+++ b/include/munin/image.hpp
@@ -73,12 +73,12 @@ protected :
     /// in order to draw onto the passed canvas.  A component must only draw
     /// the part of itself specified by the region.
     ///
-    /// \param cvs the canvas in which the component should draw itself.
+    /// \param surface the surface on which the component should draw itself.
     /// \param region the region relative to this component's origin that
     /// should be drawn.
     //* =====================================================================
     void do_draw(
-        terminalpp::canvas_view &cvs, 
+        render_surface &surface,
         rectangle const &region) const override;
 
     //* =====================================================================

--- a/include/munin/render_surface.hpp
+++ b/include/munin/render_surface.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "munin/export.hpp"
+#include "munin/render_surface_capabilities.hpp"
+#include <terminalpp/element.hpp>
+#include <terminalpp/extent.hpp>
+#include <iosfwd>
+
+namespace terminalpp {
+    class canvas;
+}
+
+namespace munin {
+
+//* =========================================================================
+/// \brief A sub-view into a canvas that only allows reading and writing
+/// to a its elements; not operations that would affect the entire canvas.
+//* =========================================================================
+class MUNIN_EXPORT render_surface
+{
+public :
+    //* =====================================================================
+    /// \brief A proxy into a row of elements on the canvas
+    //* =====================================================================
+    class row_proxy
+    {
+    public :
+        // ==================================================================
+        // CONSTRUCTOR
+        // ==================================================================
+        row_proxy(
+            render_surface &surface, 
+            terminalpp::coordinate_type column, 
+            terminalpp::coordinate_type row);
+
+        // ==================================================================
+        // OPERATOR=
+        // ==================================================================
+        row_proxy &operator=(row_proxy const &other);
+
+        // ==================================================================
+        // OPERATOR=
+        // ==================================================================
+        row_proxy &operator=(terminalpp::element const &value);
+
+        // ==================================================================
+        // CONVERSION OPERATOR: ELEMENT
+        // ==================================================================
+        operator terminalpp::element &();
+
+        // ==================================================================
+        // CONVERSION OPERATOR: ELEMENT
+        // ==================================================================
+        operator terminalpp::element const &() const;
+
+        // ==================================================================
+        // EQUALITY: ELEMENT
+        // ==================================================================
+        bool operator==(const terminalpp::element& value) const;
+        
+    private :
+        render_surface &surface_;
+        terminalpp::coordinate_type column_;
+        terminalpp::coordinate_type row_;
+    };
+
+    //* =====================================================================
+    /// \brief A proxy into a column of elements on the canvas
+    //* =====================================================================
+    class column_proxy
+    {
+    public :
+        // ==================================================================
+        // CONSTRUCTOR
+        // ==================================================================
+        column_proxy(
+            render_surface &surface, 
+            terminalpp::coordinate_type column);
+
+        // ==================================================================
+        // OPERATOR[]
+        // ==================================================================
+        row_proxy operator[](terminalpp::coordinate_type row);
+
+    private :
+        render_surface &surface_;
+        terminalpp::coordinate_type column_;
+    };
+
+    //* =====================================================================
+    /// \brief A constant proxy into a column of elements on the canvas
+    //* =====================================================================
+    class const_column_proxy
+    {
+    public :
+        // ==================================================================
+        // CONSTRUCTOR
+        // ==================================================================
+        const_column_proxy(
+            render_surface const &surface, 
+            terminalpp::coordinate_type column);
+
+        // ==================================================================
+        // OPERATOR[]
+        // ==================================================================
+        terminalpp::element const &operator[](
+            terminalpp::coordinate_type row) const;
+
+    private :
+        render_surface const &surface_;
+        terminalpp::coordinate_type column_;
+    };
+
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    explicit render_surface(terminalpp::canvas &cvs);
+
+    //* =====================================================================
+    //\ brief Constructor with explicit render surface capabilities
+    //* =====================================================================
+    render_surface(
+        terminalpp::canvas &cvs,
+        render_surface_capabilities const &capabilities);
+
+    //* =====================================================================
+    /// \brief Returns true if the surface is known to support unicode.
+    /// characters.  Attempting to render unicode on surfaces that do not
+    /// support unicode may have unexpected results.
+    //* =====================================================================
+    bool supports_unicode() const;
+
+    //* ==== =================================================================
+    /// \brief Offsets the canvas by a certain amount, causing it to become
+    /// a view with the offset location as a basis.
+    //* =====================================================================
+    void offset_by(terminalpp::extent offset);
+
+    //* =====================================================================
+    /// \brief Returns the size of the canvas.
+    //* =====================================================================
+    terminalpp::extent size() const;
+
+    //* =====================================================================
+    /// \brief A subscript operator into a column
+    //* =====================================================================
+    column_proxy operator[](terminalpp::coordinate_type column);
+
+    //* =====================================================================
+    /// \brief A subscript operator into a column
+    //* =====================================================================
+    const_column_proxy operator[](terminalpp::coordinate_type column) const;
+
+private :
+    //* =====================================================================
+    /// \brief Set the value of an element.
+    //* =====================================================================
+    void set_element(
+        terminalpp::coordinate_type column, 
+        terminalpp::coordinate_type row, 
+        terminalpp::element const &value);
+
+    //* =====================================================================
+    /// \brief Get the value of an element.
+    //* =====================================================================
+    terminalpp::element &get_element(
+        terminalpp::coordinate_type column, 
+        terminalpp::coordinate_type row);
+
+    //* =====================================================================
+    /// \brief Get the value of an element.
+    //* =====================================================================
+    terminalpp::element const &get_element(
+        terminalpp::coordinate_type column, 
+        terminalpp::coordinate_type row) const;
+
+    render_surface_capabilities const &capabilities_;
+    terminalpp::canvas &canvas_;
+    terminalpp::extent  offset_;
+};
+
+MUNIN_EXPORT
+std::ostream &operator<<(std::ostream &out, render_surface::row_proxy const &row);
+
+}

--- a/include/munin/render_surface.hpp
+++ b/include/munin/render_surface.hpp
@@ -2,13 +2,8 @@
 
 #include "munin/export.hpp"
 #include "munin/render_surface_capabilities.hpp"
-#include <terminalpp/element.hpp>
-#include <terminalpp/extent.hpp>
+#include <terminalpp/canvas.hpp>
 #include <iosfwd>
-
-namespace terminalpp {
-    class canvas;
-}
 
 namespace munin {
 

--- a/include/munin/render_surface.hpp
+++ b/include/munin/render_surface.hpp
@@ -3,7 +3,6 @@
 #include "munin/export.hpp"
 #include "munin/render_surface_capabilities.hpp"
 #include <terminalpp/canvas.hpp>
-#include <iosfwd>
 
 namespace munin {
 
@@ -31,28 +30,8 @@ public :
         // ==================================================================
         // OPERATOR=
         // ==================================================================
-        row_proxy &operator=(row_proxy const &other);
-
-        // ==================================================================
-        // OPERATOR=
-        // ==================================================================
         row_proxy &operator=(terminalpp::element const &value);
 
-        // ==================================================================
-        // CONVERSION OPERATOR: ELEMENT
-        // ==================================================================
-        operator terminalpp::element &();
-
-        // ==================================================================
-        // CONVERSION OPERATOR: ELEMENT
-        // ==================================================================
-        operator terminalpp::element const &() const;
-
-        // ==================================================================
-        // EQUALITY: ELEMENT
-        // ==================================================================
-        bool operator==(const terminalpp::element& value) const;
-        
     private :
         render_surface &surface_;
         terminalpp::coordinate_type column_;
@@ -79,30 +58,6 @@ public :
 
     private :
         render_surface &surface_;
-        terminalpp::coordinate_type column_;
-    };
-
-    //* =====================================================================
-    /// \brief A constant proxy into a column of elements on the canvas
-    //* =====================================================================
-    class const_column_proxy
-    {
-    public :
-        // ==================================================================
-        // CONSTRUCTOR
-        // ==================================================================
-        const_column_proxy(
-            render_surface const &surface, 
-            terminalpp::coordinate_type column);
-
-        // ==================================================================
-        // OPERATOR[]
-        // ==================================================================
-        terminalpp::element const &operator[](
-            terminalpp::coordinate_type row) const;
-
-    private :
-        render_surface const &surface_;
         terminalpp::coordinate_type column_;
     };
 
@@ -141,11 +96,6 @@ public :
     //* =====================================================================
     column_proxy operator[](terminalpp::coordinate_type column);
 
-    //* =====================================================================
-    /// \brief A subscript operator into a column
-    //* =====================================================================
-    const_column_proxy operator[](terminalpp::coordinate_type column) const;
-
 private :
     //* =====================================================================
     /// \brief Set the value of an element.
@@ -155,26 +105,9 @@ private :
         terminalpp::coordinate_type row, 
         terminalpp::element const &value);
 
-    //* =====================================================================
-    /// \brief Get the value of an element.
-    //* =====================================================================
-    terminalpp::element &get_element(
-        terminalpp::coordinate_type column, 
-        terminalpp::coordinate_type row);
-
-    //* =====================================================================
-    /// \brief Get the value of an element.
-    //* =====================================================================
-    terminalpp::element const &get_element(
-        terminalpp::coordinate_type column, 
-        terminalpp::coordinate_type row) const;
-
     render_surface_capabilities const &capabilities_;
     terminalpp::canvas &canvas_;
     terminalpp::extent  offset_;
 };
-
-MUNIN_EXPORT
-std::ostream &operator<<(std::ostream &out, render_surface::row_proxy const &row);
 
 }

--- a/include/munin/render_surface_capabilities.hpp
+++ b/include/munin/render_surface_capabilities.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace munin {
+
+//* =========================================================================
+/// \brief A class that describes the capabilities of a render surface.
+//* =========================================================================
+struct render_surface_capabilities
+{
+    virtual ~render_surface_capabilities() = default;
+
+    //* =====================================================================
+    /// \brief Returns true if the surface is known to support unicode.
+    /// characters.  Attempting to render unicode on surfaces that do not
+    /// support unicode may have unexpected results.
+    //* =====================================================================
+    virtual bool supports_unicode() const = 0;
+};
+
+}

--- a/include/munin/solid_frame.hpp
+++ b/include/munin/solid_frame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <munin/composite_component.hpp>
+#include "munin/composite_component.hpp"
+#include <terminalpp/attribute.hpp>
 
 namespace munin {
     

--- a/src/brush.cpp
+++ b/src/brush.cpp
@@ -1,5 +1,5 @@
 #include "munin/brush.hpp"
-#include <terminalpp/canvas_view.hpp>
+#include "munin/render_surface.hpp"
 #include <utility>
 
 using namespace terminalpp::literals;
@@ -94,7 +94,7 @@ terminalpp::extent brush::do_get_preferred_size() const
 // DO_DRAW
 // ==========================================================================
 void brush::do_draw(
-    terminalpp::canvas_view &cvs, rectangle const &region) const
+    render_surface &surface, rectangle const &region) const
 {
     for (terminalpp::coordinate_type row = region.origin.y;
          row < region.origin.y + region.size.height;
@@ -108,7 +108,7 @@ void brush::do_draw(
         {
             auto const fill_column = column % pimpl_->pattern_[fill_row].size();
 
-            cvs[column][row] = pimpl_->pattern_[fill_row][fill_column];
+            surface[column][row] = pimpl_->pattern_[fill_row][fill_column];
         }
     }
 }

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -113,9 +113,9 @@ void component::set_cursor_position(terminalpp::point const &position)
 // DRAW
 // ==========================================================================
 void component::draw(
-    terminalpp::canvas_view &cvs, rectangle const &region) const
+    render_surface &surface, rectangle const &region) const
 {
-    do_draw(cvs, region);
+    do_draw(surface, region);
 }
 
 // ==========================================================================

--- a/src/composite_component.cpp
+++ b/src/composite_component.cpp
@@ -142,10 +142,10 @@ void composite_component::do_set_cursor_position(terminalpp::point const &positi
 // DO_DRAW
 // ==========================================================================
 void composite_component::do_draw(
-    terminalpp::canvas_view &cvs,
+    render_surface &surface,
     rectangle const &region) const
 {
-    content_.draw(cvs, region);
+    content_.draw(surface, region);
 }
 
 // ==========================================================================

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -2,10 +2,10 @@
 #include "munin/layout.hpp"
 #include "munin/null_layout.hpp"
 #include "munin/rectangle.hpp"
+#include "munin/render_surface.hpp"
 #include "munin/detail/algorithm.hpp"
 #include "munin/detail/json_adaptors.hpp"
 #include <terminalpp/ansi/mouse.hpp>
-#include <terminalpp/canvas_view.hpp>
 #include <boost/optional.hpp>
 #include <boost/scope_exit.hpp>
 #include <vector>
@@ -116,11 +116,11 @@ struct container::impl
     // DRAW_COMPONENTS
     // ======================================================================
     void draw_components(
-        terminalpp::canvas_view &cvs, rectangle const &region) const
+        render_surface &surface, rectangle const &region) const
     {
         for (auto const &comp : components_)
         {
-            draw_component(comp, cvs, region);
+            draw_component(comp, surface, region);
         }
     }
 
@@ -129,7 +129,7 @@ struct container::impl
     // ======================================================================
     void draw_component(
         std::shared_ptr<component> const &comp,
-        terminalpp::canvas_view &cvs,
+        render_surface &surface,
         rectangle const &region) const
     {
         auto const component_region = rectangle {
@@ -148,22 +148,22 @@ struct container::impl
             // The canvas must have an offset applied to it so that the
             // inner component can pretend that it is being drawn with its
             // container being at position (0,0).
-            cvs.offset_by({
+            surface.offset_by({
                 component_region.origin.x,
                 component_region.origin.y
             });
 
             // Ensure that the offset is unapplied before exit of this
             // function.
-            BOOST_SCOPE_EXIT_ALL(&cvs, &component_region)
+            BOOST_SCOPE_EXIT_ALL(&surface, &component_region)
             {
-                cvs.offset_by({
+                surface.offset_by({
                     -component_region.origin.x,
                     -component_region.origin.y
                 });
             };
 
-            comp->draw(cvs, draw_region.get());
+            comp->draw(surface, draw_region.get());
         }
     }
 
@@ -684,9 +684,9 @@ void container::do_set_cursor_position(terminalpp::point const &position)
 // DO_DRAW
 // ==========================================================================
 void container::do_draw(
-    terminalpp::canvas_view &cvs, rectangle const &region) const
+    render_surface &surface, rectangle const &region) const
 {
-    pimpl_->draw_components(cvs, region);
+    pimpl_->draw_components(surface, region);
 }
 
 // ==========================================================================

--- a/src/detail/algorithm.cpp
+++ b/src/detail/algorithm.cpp
@@ -265,26 +265,5 @@ std::vector<rectangle> prune_regions(std::vector<rectangle> regions)
     return regions;
 }
 
-// ==========================================================================
-// COPY_REGION
-// ==========================================================================
-void copy_region(
-    rectangle               const &region
-  , terminalpp::canvas      const &source
-  , terminalpp::canvas_view       &destination)
-{
-    for (terminalpp::coordinate_type y_coord = region.origin.y;
-         y_coord < region.origin.y + region.size.height;
-         ++y_coord)
-    {
-        for (terminalpp::coordinate_type x_coord = region.origin.x;
-             x_coord < region.origin.x + region.size.width;
-             ++x_coord)
-        {
-            destination[x_coord][y_coord] = source[x_coord][y_coord];
-        }
-    }
-}
-
 }}
 

--- a/src/filled_box.cpp
+++ b/src/filled_box.cpp
@@ -1,5 +1,5 @@
 #include "munin/filled_box.hpp"
-#include <terminalpp/canvas_view.hpp>
+#include "munin/render_surface.hpp"
 
 namespace munin {
 
@@ -67,7 +67,7 @@ terminalpp::extent filled_box::do_get_preferred_size() const
 // DO_DRAW
 // ==========================================================================
 void filled_box::do_draw(
-    terminalpp::canvas_view &cvs, rectangle const &region) const
+    render_surface &surface, rectangle const &region) const
 {
     for (terminalpp::coordinate_type row = region.origin.y;
          row < region.origin.y + region.size.height;
@@ -77,7 +77,7 @@ void filled_box::do_draw(
              column < region.origin.x + region.size.width;
              ++column)
         {
-            cvs[column][row] = pimpl_->element_;
+            surface[column][row] = pimpl_->element_;
         }
     }
 }

--- a/src/framed_component.cpp
+++ b/src/framed_component.cpp
@@ -1,5 +1,6 @@
 #include "munin/framed_component.hpp"
 #include "munin/grid_layout.hpp"
+#include <terminalpp/ansi/mouse.hpp>
 
 namespace munin {
 namespace {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1,6 +1,6 @@
 #include "munin/image.hpp"
 #include "munin/detail/json_adaptors.hpp"
-#include <terminalpp/canvas_view.hpp>
+#include "munin/render_surface.hpp"
 #include <algorithm>
 #include <utility>
 
@@ -86,7 +86,7 @@ static void add_redraw_region(
 // DRAW_FILL_LINE
 // ==========================================================================
 static void draw_fill_line(
-    terminalpp::canvas_view &cvs,
+    render_surface &surface,
     terminalpp::point const &origin,
     terminalpp::coordinate_type const &width,
     terminalpp::element const &fill)
@@ -95,7 +95,7 @@ static void draw_fill_line(
          column < origin.x + width;
          ++column)
     {
-        cvs[column][origin.y] = fill;
+        surface[column][origin.y] = fill;
     }
 }
 
@@ -103,7 +103,7 @@ static void draw_fill_line(
 // DRAW_CONTENT_LINE
 // ==========================================================================
 static void draw_content_line(
-    terminalpp::canvas_view &cvs,
+    render_surface &surface,
     terminalpp::point const &origin,
     terminalpp::coordinate_type const &content_start,
     terminalpp::coordinate_type const &line_width,
@@ -116,7 +116,7 @@ static void draw_content_line(
             column >= content_start
          && column <  content_start + content.size();
 
-        cvs[column][origin.y] =
+        surface[column][origin.y] =
             column_has_content
           ? content[column - content_start]
           : fill;
@@ -248,7 +248,7 @@ void image::set_content(std::vector<terminalpp::string> const &content)
 // DO_DRAW
 // ==========================================================================
 void image::do_draw(
-    terminalpp::canvas_view &cvs, rectangle const &region) const
+    render_surface &surface, rectangle const &region) const
 {
     auto const size = get_size();
     auto const content_size = get_preferred_size();
@@ -265,7 +265,7 @@ void image::do_draw(
         if (row_has_content)
         {
             draw_content_line(
-                cvs,
+                surface,
                 { region.origin.x, row },
                 content_basis.x,
                 region.size.width,
@@ -275,7 +275,7 @@ void image::do_draw(
         else
         {
             draw_fill_line(
-                cvs,
+                surface,
                 { region.origin.x, row },
                 region.size.width,
                 pimpl_->fill_);

--- a/src/render_surface.cpp
+++ b/src/render_surface.cpp
@@ -1,0 +1,227 @@
+#include "munin/render_surface.hpp"
+#include <terminalpp/canvas.hpp>
+
+namespace munin {
+namespace {
+
+// ==========================================================================
+// DEFAULT RENDER SURFACE CAPABILITIES
+// ==========================================================================
+class default_render_surface_capabilities
+  : public render_surface_capabilities
+{
+public :
+    // ======================================================================
+    // SUPPORTS_UNICODE
+    // ======================================================================
+    bool supports_unicode() const override
+    {
+        return true;
+    }
+};
+
+static default_render_surface_capabilities default_capabilities;
+
+}
+
+// ==========================================================================
+// ROW_PROXY::CONSTRUCTOR
+// ==========================================================================
+render_surface::row_proxy::row_proxy(
+    render_surface& surface, 
+    terminalpp::coordinate_type column, 
+    terminalpp::coordinate_type row)
+  : surface_(surface),
+    column_(column),
+    row_(row)
+{
+}
+
+// ==========================================================================
+// ROW_PROXY::OPERATOR=
+// ==========================================================================
+render_surface::row_proxy &render_surface::row_proxy::operator=(
+    render_surface::row_proxy const &other)
+{
+    surface_.set_element(column_, row_, other);
+    return *this;
+}
+
+// ==========================================================================
+// ROW_PROXY::OPERATOR=
+// ==========================================================================
+render_surface::row_proxy &render_surface::row_proxy::operator=(
+    terminalpp::element const &value)
+{
+    surface_.set_element(column_, row_, value);
+    return *this;
+}
+
+// ==========================================================================
+// ROW_PROXY::CONVERSION OPERATOR
+// ==========================================================================
+render_surface::row_proxy::operator terminalpp::element &()
+{
+    return surface_.get_element(column_, row_);
+}
+
+// ==========================================================================
+// ROW_PROXY::CONVERSION OPERATOR
+// ==========================================================================
+render_surface::row_proxy::operator terminalpp::element const &() const
+{
+    return surface_.get_element(column_, row_);
+}
+
+// ==========================================================================
+// ROW_PROXY::OPERATOR==
+// ==========================================================================
+bool render_surface::row_proxy::operator==(
+    terminalpp::element const& value) const
+{
+    return surface_.get_element(column_, row_) == value;
+}
+
+// ==========================================================================
+// COLUMN_PROXY::CONSTRUCTOR
+// ==========================================================================
+render_surface::column_proxy::column_proxy(
+    render_surface &surface, 
+    terminalpp::coordinate_type column)
+  : surface_(surface),
+    column_(column)
+{
+}
+
+// ==========================================================================
+// COLUMN_PROXY::OPERATOR[]
+// ==========================================================================
+render_surface::row_proxy render_surface::column_proxy::operator[](
+    terminalpp::coordinate_type row)
+{
+    return render_surface::row_proxy(surface_, column_, row);
+}
+
+// ==========================================================================
+// CONST_COLUMN_PROXY::CONSTRUCTOR
+// ==========================================================================
+render_surface::const_column_proxy::const_column_proxy(
+    render_surface const &surface, 
+    terminalpp::coordinate_type column)
+  : surface_(surface),
+    column_(column)
+{
+}
+
+// ==========================================================================
+// CONST_COLUMN_PROXY::OPERATOR[]
+// ==========================================================================
+terminalpp::element const &render_surface::const_column_proxy::operator[](
+    terminalpp::coordinate_type row) const
+{
+    return surface_.get_element(column_, row);
+}
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+render_surface::render_surface(terminalpp::canvas &cvs)
+  : render_surface(cvs, default_capabilities)
+{
+}
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+render_surface::render_surface(
+    terminalpp::canvas &cvs,
+    render_surface_capabilities const &capabilities)
+  : canvas_(cvs),
+    capabilities_(capabilities)
+{
+}
+
+// ==========================================================================
+// SUPPORTS_UNICODE
+// ==========================================================================
+bool render_surface::supports_unicode() const
+{
+    return capabilities_.supports_unicode();
+}
+
+// ==========================================================================
+// OFFSET_BY
+// ==========================================================================
+void render_surface::offset_by(
+    terminalpp::extent offset)
+{
+    offset_ += offset;
+}
+
+// ==========================================================================
+// SIZE
+// ==========================================================================
+terminalpp::extent render_surface::size() const
+{
+    return canvas_.size() - offset_;
+}
+
+// ==========================================================================
+// OPERATOR[]
+// ==========================================================================
+render_surface::column_proxy render_surface::operator[](
+    terminalpp::coordinate_type column)
+{
+    return column_proxy(*this, column);
+}
+
+// ==========================================================================
+// OPERATOR[]
+// ==========================================================================
+render_surface::const_column_proxy render_surface::operator[](
+    terminalpp::coordinate_type column) const
+{
+    return const_column_proxy(*this, column);
+}
+
+// ==========================================================================
+// GET_ELEMENT
+// ==========================================================================
+terminalpp::element &render_surface::get_element(
+    terminalpp::coordinate_type column, terminalpp::coordinate_type row)
+{
+    return canvas_[column + offset_.width][row + offset_.height];
+}
+
+// ==========================================================================
+// GET_ELEMENT
+// ==========================================================================
+terminalpp::element const &render_surface::get_element(
+    terminalpp::coordinate_type column, 
+    terminalpp::coordinate_type row) const
+{
+    return canvas_[column + offset_.width][row + offset_.height];
+}
+
+// ==========================================================================
+// SET_ELEMENT
+// ==========================================================================
+void render_surface::set_element(
+    terminalpp::coordinate_type column, 
+    terminalpp::coordinate_type row, 
+    terminalpp::element const &value)
+{
+    canvas_[column + offset_.width][row + offset_.height] = value;
+}
+
+// ==========================================================================
+// OPERATOR<<(row_proxy)
+// ==========================================================================
+std::ostream &operator<<(
+    std::ostream &out,
+    render_surface::row_proxy const &row)
+{
+    return out << terminalpp::element(row);
+}
+
+}

--- a/src/render_surface.cpp
+++ b/src/render_surface.cpp
@@ -1,5 +1,4 @@
 #include "munin/render_surface.hpp"
-#include <terminalpp/canvas.hpp>
 
 namespace munin {
 namespace {

--- a/src/render_surface.cpp
+++ b/src/render_surface.cpp
@@ -40,45 +40,10 @@ render_surface::row_proxy::row_proxy(
 // ROW_PROXY::OPERATOR=
 // ==========================================================================
 render_surface::row_proxy &render_surface::row_proxy::operator=(
-    render_surface::row_proxy const &other)
-{
-    surface_.set_element(column_, row_, other);
-    return *this;
-}
-
-// ==========================================================================
-// ROW_PROXY::OPERATOR=
-// ==========================================================================
-render_surface::row_proxy &render_surface::row_proxy::operator=(
     terminalpp::element const &value)
 {
     surface_.set_element(column_, row_, value);
     return *this;
-}
-
-// ==========================================================================
-// ROW_PROXY::CONVERSION OPERATOR
-// ==========================================================================
-render_surface::row_proxy::operator terminalpp::element &()
-{
-    return surface_.get_element(column_, row_);
-}
-
-// ==========================================================================
-// ROW_PROXY::CONVERSION OPERATOR
-// ==========================================================================
-render_surface::row_proxy::operator terminalpp::element const &() const
-{
-    return surface_.get_element(column_, row_);
-}
-
-// ==========================================================================
-// ROW_PROXY::OPERATOR==
-// ==========================================================================
-bool render_surface::row_proxy::operator==(
-    terminalpp::element const& value) const
-{
-    return surface_.get_element(column_, row_) == value;
 }
 
 // ==========================================================================
@@ -99,26 +64,6 @@ render_surface::row_proxy render_surface::column_proxy::operator[](
     terminalpp::coordinate_type row)
 {
     return render_surface::row_proxy(surface_, column_, row);
-}
-
-// ==========================================================================
-// CONST_COLUMN_PROXY::CONSTRUCTOR
-// ==========================================================================
-render_surface::const_column_proxy::const_column_proxy(
-    render_surface const &surface, 
-    terminalpp::coordinate_type column)
-  : surface_(surface),
-    column_(column)
-{
-}
-
-// ==========================================================================
-// CONST_COLUMN_PROXY::OPERATOR[]
-// ==========================================================================
-terminalpp::element const &render_surface::const_column_proxy::operator[](
-    terminalpp::coordinate_type row) const
-{
-    return surface_.get_element(column_, row);
 }
 
 // ==========================================================================
@@ -175,34 +120,6 @@ render_surface::column_proxy render_surface::operator[](
 }
 
 // ==========================================================================
-// OPERATOR[]
-// ==========================================================================
-render_surface::const_column_proxy render_surface::operator[](
-    terminalpp::coordinate_type column) const
-{
-    return const_column_proxy(*this, column);
-}
-
-// ==========================================================================
-// GET_ELEMENT
-// ==========================================================================
-terminalpp::element &render_surface::get_element(
-    terminalpp::coordinate_type column, terminalpp::coordinate_type row)
-{
-    return canvas_[column + offset_.width][row + offset_.height];
-}
-
-// ==========================================================================
-// GET_ELEMENT
-// ==========================================================================
-terminalpp::element const &render_surface::get_element(
-    terminalpp::coordinate_type column, 
-    terminalpp::coordinate_type row) const
-{
-    return canvas_[column + offset_.width][row + offset_.height];
-}
-
-// ==========================================================================
 // SET_ELEMENT
 // ==========================================================================
 void render_surface::set_element(
@@ -211,16 +128,6 @@ void render_surface::set_element(
     terminalpp::element const &value)
 {
     canvas_[column + offset_.width][row + offset_.height] = value;
-}
-
-// ==========================================================================
-// OPERATOR<<(row_proxy)
-// ==========================================================================
-std::ostream &operator<<(
-    std::ostream &out,
-    render_surface::row_proxy const &row)
-{
-    return out << terminalpp::element(row);
 }
 
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1,5 +1,6 @@
 #include "munin/window.hpp"
 #include "munin/component.hpp"
+#include "munin/render_surface.hpp"
 #include "munin/detail/json_adaptors.hpp"
 #include <terminalpp/screen.hpp>
 #include <terminalpp/terminal.hpp>
@@ -96,10 +97,10 @@ std::string window::repaint(
         repaint_regions.swap(pimpl_->repaint_regions_);
     }
 
-    terminalpp::canvas_view cvs_view(cvs);
+    render_surface surface(cvs);
     for (auto const &region : repaint_regions)
     {
-        pimpl_->content_->draw(cvs_view, region);
+        pimpl_->content_->draw(surface, region);
     }
 
     return pimpl_->screen_.draw(term, cvs);

--- a/test/include/mock/component.hpp
+++ b/test/include/mock/component.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <terminalpp/canvas_view.hpp>
 #include <munin/component.hpp>
+#include <munin/render_surface.hpp>
 #include <gmock/gmock.h>
 
 class mock_component : public munin::component
@@ -138,7 +138,7 @@ public :
     /// should be drawn.
     //* =====================================================================
     MOCK_CONST_METHOD2(do_draw, 
-        void (terminalpp::canvas_view &, munin::rectangle const &));
+        void (munin::render_surface &, munin::rectangle const &));
 
     //* =====================================================================
     /// \brief Called by event().  Derived classes must override this

--- a/test/src/basic_component/fake_basic_component.hpp
+++ b/test/src/basic_component/fake_basic_component.hpp
@@ -12,7 +12,7 @@ private :
     }
     
     void do_draw(
-        terminalpp::canvas_view &cvs, 
+        munin::render_surface &surface, 
         munin::rectangle const &region) const override
     {
     }

--- a/test/src/brush/brush_test.cpp
+++ b/test/src/brush/brush_test.cpp
@@ -1,6 +1,6 @@
 #include <munin/brush.hpp>
+#include <munin/render_surface.hpp>
 #include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
 #include <gtest/gtest.h>
 
 TEST(a_brush_with_its_pattern_set_empty, draws_whitespace_on_the_canvas)
@@ -35,7 +35,7 @@ TEST(a_brush_with_its_pattern_set_empty, draws_whitespace_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
+    munin::render_surface cv{canvas};
     brush.draw(cv, {{}, brush.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
@@ -83,7 +83,7 @@ TEST(a_brush_with_its_pattern_set_to_a_single_line_pattern, draws_that_pattern_r
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
+    munin::render_surface cv{canvas};
     cv.offset_by({1, 1});
     brush.draw(cv, {{}, brush.get_size()});
 
@@ -162,7 +162,7 @@ TEST(a_brush_with_its_pattern_set_to_a_multi_line_pattern, draws_that_pattern_re
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
+    munin::render_surface cv{canvas};
     cv.offset_by({1, 1});
     brush.draw(cv, {{}, brush.get_size()});
 

--- a/test/src/brush/new_brush_test.cpp
+++ b/test/src/brush/new_brush_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/brush.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 TEST(a_new_brush, has_a_singular_preferred_size)
@@ -50,8 +49,8 @@ TEST(a_new_brush, draws_whitespace_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    brush.draw(cv, {{}, brush.get_size()});
+    munin::render_surface surface{canvas};
+    brush.draw(surface, {{}, brush.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
@@ -86,9 +85,9 @@ TEST(a_new_brush_with_a_single_line_pattern, draws_that_pattern_repeatedly)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    cv.offset_by({1, 1});
-    brush.draw(cv, {{}, brush.get_size()});
+    munin::render_surface surface{canvas};
+    surface.offset_by({1, 1});
+    brush.draw(surface, {{}, brush.get_size()});
 
     ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);
@@ -152,9 +151,9 @@ TEST(a_new_brush_with_a_multi_line_pattern, draws_that_pattern_repeatedly)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    cv.offset_by({1, 1});
-    brush.draw(cv, {{}, brush.get_size()});
+    munin::render_surface surface{canvas};
+    surface.offset_by({1, 1});
+    brush.draw(surface, {{}, brush.get_size()});
 
     ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);

--- a/test/src/container/container_draw_test.cpp
+++ b/test/src/container/container_draw_test.cpp
@@ -1,6 +1,5 @@
 #include "container_test.hpp"
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 
 using testing::_;
 using testing::Return;
@@ -14,7 +13,7 @@ TEST_F(a_container, draws_subcomponent_when_drawn)
     container.add_component(component);
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
+    munin::render_surface surface{canvas};
 
     EXPECT_CALL(*component, do_get_position())
         .WillOnce(Return(terminalpp::point(0, 0)));
@@ -23,7 +22,7 @@ TEST_F(a_container, draws_subcomponent_when_drawn)
 
     EXPECT_CALL(*component, do_draw(_, munin::rectangle({0, 0}, {2, 2})));
 
-    container.draw(cv, munin::rectangle({0, 0}, {2, 2}));
+    container.draw(surface, munin::rectangle({0, 0}, {2, 2}));
 }
 
 TEST_F(a_container, draws_partial_subcomponents_when_partially_drawn)
@@ -35,7 +34,7 @@ TEST_F(a_container, draws_partial_subcomponents_when_partially_drawn)
     container.add_component(component);
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
+    munin::render_surface surface{canvas};
 
     EXPECT_CALL(*component, do_get_position())
         .WillOnce(Return(terminalpp::point(0, 0)));
@@ -44,7 +43,7 @@ TEST_F(a_container, draws_partial_subcomponents_when_partially_drawn)
 
     EXPECT_CALL(*component, do_draw(_, munin::rectangle({1, 0}, {1, 2})));
 
-    container.draw(cv, munin::rectangle({1, 0}, {1, 2}));
+    container.draw(surface, munin::rectangle({1, 0}, {1, 2}));
 }
 
 TEST_F(a_container, does_not_draw_subcomponents_outside_of_draw_region)
@@ -56,14 +55,14 @@ TEST_F(a_container, does_not_draw_subcomponents_outside_of_draw_region)
     container.add_component(component);
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
+    munin::render_surface surface{canvas};
 
     EXPECT_CALL(*component, do_get_position())
         .WillOnce(Return(terminalpp::point(1, 0)));
     EXPECT_CALL(*component, do_get_size())
         .WillOnce(Return(terminalpp::extent(1, 2)));
 
-    container.draw(cv, munin::rectangle({0, 0}, {1, 2}));
+    container.draw(surface, munin::rectangle({0, 0}, {1, 2}));
 }
 
 TEST_F(a_container, offsets_canvas_before_drawing_offset_components)
@@ -75,7 +74,7 @@ TEST_F(a_container, offsets_canvas_before_drawing_offset_components)
     container.add_component(component);
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
+    munin::render_surface surface{canvas};
 
     EXPECT_CALL(*component, do_get_position())
         .WillOnce(Return(terminalpp::point(1, 0)));
@@ -84,7 +83,7 @@ TEST_F(a_container, offsets_canvas_before_drawing_offset_components)
 
     EXPECT_CALL(*component, do_draw(_, munin::rectangle({0, 0}, {1, 2})));
 
-    container.draw(cv, munin::rectangle({0, 0}, {2, 2}));
+    container.draw(surface, munin::rectangle({0, 0}, {2, 2}));
 }
 
 TEST_F(a_container, draws_many_components_when_drawing)
@@ -101,7 +100,7 @@ TEST_F(a_container, draws_many_components_when_drawing)
     container.add_component(component_br);
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
+    munin::render_surface surface{canvas};
 
     EXPECT_CALL(*component_tl, do_get_position())
         .WillOnce(Return(terminalpp::point(0, 0)));
@@ -127,5 +126,5 @@ TEST_F(a_container, draws_many_components_when_drawing)
         .WillOnce(Return(terminalpp::extent(2, 2)));
     EXPECT_CALL(*component_br, do_draw(_, munin::rectangle({0, 0}, {1, 1})));
 
-    container.draw(cv, munin::rectangle({1, 1}, {2, 2}));
+    container.draw(surface, munin::rectangle({1, 1}, {2, 2}));
 }

--- a/test/src/container/container_test.cpp
+++ b/test/src/container/container_test.cpp
@@ -1,6 +1,5 @@
 #include "container_test.hpp"
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 
 using testing::Return;
 using testing::_;
@@ -71,8 +70,8 @@ TEST_F(a_new_container, draws_nothing)
     
     container.set_size({1, 1});
     
-    terminalpp::canvas_view cv(canvas);
-    container.draw(cv, {{0, 0}, {1, 1}});
+    munin::render_surface surface{canvas};
+    container.draw(surface, {{0, 0}, {1, 1}});
     
     ASSERT_EQ(terminalpp::element('?'), canvas[0][0]);
 }

--- a/test/src/filled_box/filled_box_test.cpp
+++ b/test/src/filled_box/filled_box_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/filled_box.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 TEST(make_fill, make_a_new_filled_box)
@@ -53,8 +52,9 @@ TEST(a_filled_box, draws_its_fill)
     filled_box.set_size({1, 1});
 
     terminalpp::canvas canvas({2, 2});
-    terminalpp::canvas_view cv(canvas);
-    filled_box.draw(cv, {{}, {1, 1}});
+    munin::render_surface surface{canvas};
+    
+    filled_box.draw(surface, {{}, {1, 1}});
 
     ASSERT_EQ(terminalpp::element('Y'), canvas[0][0]);
     ASSERT_EQ(terminalpp::element(' '), canvas[0][1]);
@@ -69,10 +69,10 @@ TEST(a_filled_box, draws_only_within_given_region)
     filled_box.set_size({2, 2});
 
     terminalpp::canvas canvas({3, 4});
-    terminalpp::canvas_view cv(canvas);
-    cv.offset_by({1, 1});
+    munin::render_surface surface{canvas};
+    surface.offset_by({1, 1});
 
-    filled_box.draw(cv, {{}, {1, 2}});
+    filled_box.draw(surface, {{}, {1, 2}});
 
     ASSERT_EQ(terminalpp::element(' '), canvas[0][0]);
     ASSERT_EQ(terminalpp::element(' '), canvas[1][0]);

--- a/test/src/filled_box/new_filled_box_test.cpp
+++ b/test/src/filled_box/new_filled_box_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/filled_box.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 TEST(a_new_filled_box, has_a_whitespace_fill)
@@ -34,8 +33,8 @@ TEST(a_new_filled_box, draws_whitespace_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    filled_box.draw(cv, {{}, filled_box.get_size()});
+    munin::render_surface surface{canvas};
+    filled_box.draw(surface, {{}, filled_box.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);

--- a/test/src/framed_component/framed_component_test.cpp
+++ b/test/src/framed_component/framed_component_test.cpp
@@ -2,8 +2,7 @@
 #include <munin/filled_box.hpp>
 #include <munin/framed_component.hpp>
 #include <munin/solid_frame.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 using testing::Return;
@@ -129,9 +128,9 @@ TEST(a_framed_component, draws_the_inner_component_inside_the_frame)
     comp->set_size({4, 4});
     
     terminalpp::canvas cvs({4, 4});
-    terminalpp::canvas_view cvs_view(cvs);
+    munin::render_surface surface{cvs};
     
-    comp->draw(cvs_view, {{0, 0}, {4, 4}});
+    comp->draw(surface, {{0, 0}, {4, 4}});
     
     ASSERT_EQ(default_attribute, cvs[0][0].attribute_);
     ASSERT_EQ(default_attribute, cvs[1][0].attribute_);

--- a/test/src/image/image_test.cpp
+++ b/test/src/image/image_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/image.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 TEST(an_image_with_its_content_set_empty, draws_fill_on_the_canvas)
@@ -25,8 +24,8 @@ TEST(an_image_with_its_content_set_empty, draws_fill_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -70,8 +69,8 @@ TEST(an_image_with_its_content_set_to_single_line, draws_line_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -120,8 +119,8 @@ TEST(an_image_with_its_content_set_to_multi_line, draws_lines_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -172,8 +171,8 @@ TEST(an_image, sets_its_content_empty_when_set_to_an_empty_string)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -202,8 +201,8 @@ TEST(an_image, can_have_its_fill_set)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{'!'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'!'}, canvas[1][0]);

--- a/test/src/image/new_image_test.cpp
+++ b/test/src/image/new_image_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/image.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
 
 TEST(a_new_image, has_a_zero_preferred_size)
@@ -92,8 +91,8 @@ TEST(a_new_image, draws_whitespace_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
@@ -125,8 +124,8 @@ TEST(a_new_image_with_a_fill, draws_fill_on_the_canvas)
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][1]);
@@ -161,8 +160,8 @@ TEST(a_new_image_with_a_single_line_content, draws_that_content_centred_with_whi
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -205,8 +204,8 @@ TEST(a_new_image_with_a_single_line_content_and_fill, draws_that_content_centred
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'Z'}, canvas[1][0]);
@@ -253,8 +252,8 @@ TEST(a_new_image_with_multi_line_content, draws_that_content_centred_with_whites
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
@@ -313,8 +312,8 @@ TEST(a_new_image_with_multi_line_content_with_fill, draws_that_content_centred_w
         }
     }
 
-    terminalpp::canvas_view cv{canvas};
-    image.draw(cv, {{}, image.get_size()});
+    munin::render_surface surface{canvas};
+    image.draw(surface, {{}, image.get_size()});
 
     ASSERT_EQ(terminalpp::element{'T'}, canvas[0][0]);
     ASSERT_EQ(terminalpp::element{'T'}, canvas[1][0]);

--- a/test/src/render_surface/render_surface_capabilities_test.cpp
+++ b/test/src/render_surface/render_surface_capabilities_test.cpp
@@ -1,0 +1,53 @@
+#include <munin/render_surface.hpp>
+#include <munin/render_surface_capabilities.hpp>
+#include <terminalpp/canvas.hpp>
+
+#include <gtest/gtest.h>
+
+using testing::Values;
+
+TEST(a_render_surface, supports_unicode_by_default)
+{
+    terminalpp::canvas cvs({1, 1});
+    munin::render_surface rs(cvs);
+
+    ASSERT_TRUE(rs.supports_unicode());
+}
+
+class render_surface_with_optional_unicode_capability
+  : public testing::TestWithParam<bool>
+{
+};
+
+TEST_P(render_surface_with_optional_unicode_capability, returns_that_capability_from_supports_unicode)
+{
+    auto const &unicode_support = GetParam();
+
+    struct unicode_render_surface_capabilities
+      : public munin::render_surface_capabilities
+    {
+        unicode_render_surface_capabilities(bool unicode_support)
+          : unicode_support_(unicode_support)
+        {
+        }
+
+        bool supports_unicode() const override
+        {
+            return unicode_support_;
+        }
+
+        bool unicode_support_;
+    };
+
+    terminalpp::canvas cvs({1, 1});
+    unicode_render_surface_capabilities caps(unicode_support);
+    munin::render_surface rs(cvs, caps);
+
+    ASSERT_EQ(unicode_support, rs.supports_unicode());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    render_surfaces_reflect_unicode_support_from_capabilities,
+    render_surface_with_optional_unicode_capability,
+    Values(true, false)
+);

--- a/test/src/render_surface/render_surface_capabilities_test.cpp
+++ b/test/src/render_surface/render_surface_capabilities_test.cpp
@@ -1,6 +1,5 @@
 #include <munin/render_surface.hpp>
 #include <munin/render_surface_capabilities.hpp>
-#include <terminalpp/canvas.hpp>
 
 #include <gtest/gtest.h>
 

--- a/test/src/render_surface/render_surface_capabilities_test.cpp
+++ b/test/src/render_surface/render_surface_capabilities_test.cpp
@@ -25,7 +25,7 @@ TEST_P(render_surface_with_optional_unicode_capability, returns_that_capability_
     struct unicode_render_surface_capabilities
       : public munin::render_surface_capabilities
     {
-        unicode_render_surface_capabilities(bool unicode_support)
+        explicit unicode_render_surface_capabilities(bool unicode_support)
           : unicode_support_(unicode_support)
         {
         }

--- a/test/src/render_surface/render_surface_test.cpp
+++ b/test/src/render_surface/render_surface_test.cpp
@@ -32,7 +32,6 @@ TEST(render_surface_test, offset_render_surface_has_offset_basis)
 
     render_surface.offset_by({1, 1});
     render_surface[0][0] = 'x';
-    ASSERT_TRUE(render_surface[0][0] == 'x');
 
     ASSERT_TRUE(canvas[0][0] == ' ');
     ASSERT_TRUE(canvas[0][1] == ' ');

--- a/test/src/render_surface/render_surface_test.cpp
+++ b/test/src/render_surface/render_surface_test.cpp
@@ -1,5 +1,4 @@
 #include <munin/render_surface.hpp>
-#include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
 TEST(render_surface_test, default_render_surface_views_same_basis_as_canvas)

--- a/test/src/render_surface/render_surface_test.cpp
+++ b/test/src/render_surface/render_surface_test.cpp
@@ -1,0 +1,66 @@
+#include <munin/render_surface.hpp>
+#include <terminalpp/canvas.hpp>
+#include <gtest/gtest.h>
+
+TEST(render_surface_test, default_render_surface_views_same_basis_as_canvas)
+{
+    terminalpp::canvas canvas({2, 2});
+    munin::render_surface render_surface(canvas);
+
+    render_surface[0][0] = 'a';
+    render_surface[0][1] = 'b';
+    render_surface[1][0] = 'c';
+    render_surface[1][1] = 'd';
+
+    ASSERT_TRUE(canvas[0][0] == 'a');
+    ASSERT_TRUE(canvas[0][1] == 'b');
+    ASSERT_TRUE(canvas[1][0] == 'c');
+    ASSERT_TRUE(canvas[1][1] == 'd');
+}
+
+TEST(render_surface_test, default_render_surface_has_same_size_as_canvas)
+{
+    terminalpp::canvas canvas({2, 2});
+    munin::render_surface render_surface(canvas);
+
+    ASSERT_EQ(canvas.size(), render_surface.size());
+}
+
+TEST(render_surface_test, offset_render_surface_has_offset_basis)
+{
+    terminalpp::canvas canvas({2, 2});
+    munin::render_surface render_surface(canvas);
+
+    render_surface.offset_by({1, 1});
+    render_surface[0][0] = 'x';
+    ASSERT_TRUE(render_surface[0][0] == 'x');
+
+    ASSERT_TRUE(canvas[0][0] == ' ');
+    ASSERT_TRUE(canvas[0][1] == ' ');
+    ASSERT_TRUE(canvas[1][0] == ' ');
+    ASSERT_TRUE(canvas[1][1] == 'x');
+}
+
+TEST(render_surface_test, offset_render_surface_has_reduced_size)
+{
+    terminalpp::canvas canvas({2, 2});
+    munin::render_surface render_surface(canvas);
+
+    render_surface.offset_by({1, 1});
+
+    ASSERT_EQ(
+        (canvas.size() - terminalpp::extent{1, 1}),
+        render_surface.size());
+}
+
+TEST(render_surface_test, offset_is_cumulative)
+{
+    terminalpp::canvas canvas({3, 3});
+    munin::render_surface render_surface(canvas);
+
+    render_surface.offset_by({1, 1});
+    render_surface.offset_by({1, 1});
+
+    render_surface[0][0] = 'x';
+    ASSERT_TRUE(canvas[2][2] == 'x');
+}

--- a/test/src/solid_frame/solid_frame_test.cpp
+++ b/test/src/solid_frame/solid_frame_test.cpp
@@ -1,8 +1,7 @@
 #include "mock/component.hpp"
 #include "mock/graphics.hpp"
 #include <munin/solid_frame.hpp>
-#include <terminalpp/canvas.hpp>
-#include <terminalpp/canvas_view.hpp>
+#include <munin/render_surface.hpp>
 #include <terminalpp/string.hpp>
 #include <gtest/gtest.h>
 
@@ -40,21 +39,21 @@ TEST(a_solid_frame, draws_a_border)
     frame.set_size({4, 4});
     
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(top_left_corner,     cv[0][0]);
-    ASSERT_EQ(horizontal_beam,     cv[1][0]);
-    ASSERT_EQ(horizontal_beam,     cv[2][0]);
-    ASSERT_EQ(top_right_corner,    cv[3][0]);
-    ASSERT_EQ(vertical_beam,       cv[0][1]);
-    ASSERT_EQ(vertical_beam,       cv[3][1]);
-    ASSERT_EQ(vertical_beam,       cv[0][2]);
-    ASSERT_EQ(vertical_beam,       cv[3][2]);
-    ASSERT_EQ(bottom_left_corner,  cv[0][3]);
-    ASSERT_EQ(horizontal_beam,     cv[1][3]);
-    ASSERT_EQ(horizontal_beam,     cv[2][3]);
-    ASSERT_EQ(bottom_right_corner, cv[3][3]);
+    ASSERT_EQ(top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][0]);
+    ASSERT_EQ(top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(vertical_beam,       canvas[0][1]);
+    ASSERT_EQ(vertical_beam,       canvas[3][1]);
+    ASSERT_EQ(vertical_beam,       canvas[0][2]);
+    ASSERT_EQ(vertical_beam,       canvas[3][2]);
+    ASSERT_EQ(bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][3]);
+    ASSERT_EQ(bottom_right_corner, canvas[3][3]);
 }
 
 class a_solid_frame_with_unicode_graphics : public testing::Test
@@ -82,21 +81,21 @@ TEST_F(a_solid_frame_with_unicode_graphics, draws_a_border_with_box_drawing_glyp
     frame.set_size({4, 4});
     
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(unicode_top_left_corner,     terminalpp::element(cv[0][0]));
-    ASSERT_EQ(unicode_horizontal_beam,     cv[1][0]);
-    ASSERT_EQ(unicode_horizontal_beam,     cv[2][0]);
-    ASSERT_EQ(unicode_top_right_corner,    cv[3][0]);
-    ASSERT_EQ(unicode_vertical_beam,       cv[0][1]);
-    ASSERT_EQ(unicode_vertical_beam,       cv[0][2]);
-    ASSERT_EQ(unicode_vertical_beam,       cv[3][2]);
-    ASSERT_EQ(unicode_vertical_beam,       cv[3][1]);
-    ASSERT_EQ(unicode_bottom_left_corner,  cv[0][3]);
-    ASSERT_EQ(unicode_horizontal_beam,     cv[1][3]);
-    ASSERT_EQ(unicode_horizontal_beam,     cv[2][3]);
-    ASSERT_EQ(unicode_bottom_right_corner, cv[3][3]);
+    ASSERT_EQ(unicode_top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(unicode_horizontal_beam,     canvas[1][0]);
+    ASSERT_EQ(unicode_horizontal_beam,     canvas[2][0]);
+    ASSERT_EQ(unicode_top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(unicode_vertical_beam,       canvas[0][1]);
+    ASSERT_EQ(unicode_vertical_beam,       canvas[0][2]);
+    ASSERT_EQ(unicode_vertical_beam,       canvas[3][2]);
+    ASSERT_EQ(unicode_vertical_beam,       canvas[3][1]);
+    ASSERT_EQ(unicode_bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(unicode_horizontal_beam,     canvas[1][3]);
+    ASSERT_EQ(unicode_horizontal_beam,     canvas[2][3]);
+    ASSERT_EQ(unicode_bottom_right_corner, canvas[3][3]);
 }
 
 TEST(a_solid_frame, can_be_displayed_with_a_custom_lowlight)
@@ -111,22 +110,21 @@ TEST(a_solid_frame, can_be_displayed_with_a_custom_lowlight)
     frame.set_lowlight_attribute(lowlight_attribute);
     
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
-    
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), cv[0][0]);
-    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), cv[1][0]);
-    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), cv[2][0]);
-    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), cv[3][0]);
-    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), cv[0][1]);
-    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), cv[3][1]);
-    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), cv[0][2]);
-    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), cv[3][2]);
-    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), cv[0][3]);
-    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), cv[1][3]);
-    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), cv[2][3]);
-    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), cv[3][3]);
+    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[0][0]);
+    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[1][0]);
+    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[2][0]);
+    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[3][0]);
+    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[0][1]);
+    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[3][1]);
+    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[0][2]);
+    ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[3][2]);
+    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[0][3]);
+    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[1][3]);
+    ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[2][3]);
+    ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[3][3]);
 }
 
 TEST(a_solid_frame_with_an_associated_unfocussed_component, draws_a_highlighted_border)
@@ -141,21 +139,21 @@ TEST(a_solid_frame_with_an_associated_unfocussed_component, draws_a_highlighted_
     frame.set_size({4, 4});
 
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(top_left_corner,     cv[0][0]);
-    ASSERT_EQ(horizontal_beam,     cv[1][0]);
-    ASSERT_EQ(horizontal_beam,     cv[2][0]);
-    ASSERT_EQ(top_right_corner,    cv[3][0]);
-    ASSERT_EQ(vertical_beam,       cv[0][1]);
-    ASSERT_EQ(vertical_beam,       cv[3][1]);
-    ASSERT_EQ(vertical_beam,       cv[0][2]);
-    ASSERT_EQ(vertical_beam,       cv[3][2]);
-    ASSERT_EQ(bottom_left_corner,  cv[0][3]);
-    ASSERT_EQ(horizontal_beam,     cv[1][3]);
-    ASSERT_EQ(horizontal_beam,     cv[2][3]);
-    ASSERT_EQ(bottom_right_corner, cv[3][3]);
+    ASSERT_EQ(top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][0]);
+    ASSERT_EQ(top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(vertical_beam,       canvas[0][1]);
+    ASSERT_EQ(vertical_beam,       canvas[3][1]);
+    ASSERT_EQ(vertical_beam,       canvas[0][2]);
+    ASSERT_EQ(vertical_beam,       canvas[3][2]);
+    ASSERT_EQ(bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][3]);
+    ASSERT_EQ(bottom_right_corner, canvas[3][3]);
 }
 
 TEST(a_solid_frame_with_an_associated_unfocussed_component, when_focussed_draws_a_highlighted_border)
@@ -174,21 +172,21 @@ TEST(a_solid_frame_with_an_associated_unfocussed_component, when_focussed_draws_
     comp->on_focus_set();
 
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(terminalpp::element(top_left_corner,     highlight_attribute), cv[0][0]);
-    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), cv[1][0]);
-    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), cv[2][0]);
-    ASSERT_EQ(terminalpp::element(top_right_corner,    highlight_attribute), cv[3][0]);
-    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), cv[3][2]);
-    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), cv[0][1]);
-    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), cv[3][1]);
-    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), cv[0][2]);
-    ASSERT_EQ(terminalpp::element(bottom_left_corner,  highlight_attribute), cv[0][3]);
-    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), cv[1][3]);
-    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), cv[2][3]);
-    ASSERT_EQ(terminalpp::element(bottom_right_corner, highlight_attribute), cv[3][3]);
+    ASSERT_EQ(terminalpp::element(top_left_corner,     highlight_attribute), canvas[0][0]);
+    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[1][0]);
+    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[2][0]);
+    ASSERT_EQ(terminalpp::element(top_right_corner,    highlight_attribute), canvas[3][0]);
+    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), canvas[3][2]);
+    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), canvas[0][1]);
+    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), canvas[3][1]);
+    ASSERT_EQ(terminalpp::element(vertical_beam,       highlight_attribute), canvas[0][2]);
+    ASSERT_EQ(terminalpp::element(bottom_left_corner,  highlight_attribute), canvas[0][3]);
+    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[1][3]);
+    ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[2][3]);
+    ASSERT_EQ(terminalpp::element(bottom_right_corner, highlight_attribute), canvas[3][3]);
 }
 
 TEST(a_solid_frame_with_an_associated_focussed_component, when_unfocussed_draws_a_border)
@@ -207,19 +205,19 @@ TEST(a_solid_frame_with_an_associated_focussed_component, when_unfocussed_draws_
     comp->on_focus_lost();
 
     terminalpp::canvas canvas({4, 4});
-    terminalpp::canvas_view cv(canvas);
-    frame.draw(cv, {{}, {4, 4}});
+    munin::render_surface surface{canvas};
+    frame.draw(surface, {{}, {4, 4}});
 
-    ASSERT_EQ(top_left_corner,     cv[0][0]);
-    ASSERT_EQ(horizontal_beam,     cv[1][0]);
-    ASSERT_EQ(horizontal_beam,     cv[2][0]);
-    ASSERT_EQ(top_right_corner,    cv[3][0]);
-    ASSERT_EQ(vertical_beam,       cv[0][1]);
-    ASSERT_EQ(vertical_beam,       cv[3][1]);
-    ASSERT_EQ(vertical_beam,       cv[0][2]);
-    ASSERT_EQ(vertical_beam,       cv[3][2]);
-    ASSERT_EQ(bottom_left_corner,  cv[0][3]);
-    ASSERT_EQ(horizontal_beam,     cv[1][3]);
-    ASSERT_EQ(horizontal_beam,     cv[2][3]);
-    ASSERT_EQ(bottom_right_corner, cv[3][3]);
+    ASSERT_EQ(top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][0]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][0]);
+    ASSERT_EQ(top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(vertical_beam,       canvas[0][1]);
+    ASSERT_EQ(vertical_beam,       canvas[3][1]);
+    ASSERT_EQ(vertical_beam,       canvas[0][2]);
+    ASSERT_EQ(vertical_beam,       canvas[3][2]);
+    ASSERT_EQ(bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[1][3]);
+    ASSERT_EQ(horizontal_beam,     canvas[2][3]);
+    ASSERT_EQ(bottom_right_corner, canvas[3][3]);
 }


### PR DESCRIPTION
Adds a render_surface, which is a replacement for (the soon-to-be-removed) canvas_view, which implements the same features, and also exposes capabilities of the surface (e.g. if it supports Unicode.)

closes #113.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/114)
<!-- Reviewable:end -->
