### PR TITLE
Frame focus redraw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ if (GTEST_FOUND)
     enable_testing()
 
     set (MUNIN_TEST_SOURCE_FILES
+        test/src/redraw.cpp
         test/src/mock/component.cpp
         test/src/algorithm/algorithm_test.cpp
         test/src/aligned_layout/aligned_layout_test.cpp
@@ -205,6 +206,7 @@ if (GTEST_FOUND)
     set (MUNIN_TEST_INCLUDE_FILES
         test/src/container/container_test.hpp
         test/src/window/window_test.hpp
+        test/include/redraw.hpp
         test/include/mock/component.hpp
         test/include/mock/layout.hpp
         test/include/mock/terminal.hpp

--- a/src/solid_frame.cpp
+++ b/src/solid_frame.cpp
@@ -8,19 +8,52 @@ namespace munin {
 
 struct solid_frame::impl
 {
+    impl(solid_frame &self)
+      : self(self)
+    {
+    }
+    
+    solid_frame &self;
     terminalpp::attribute lowlight_attribute;
     terminalpp::attribute highlight_attribute = {
         terminalpp::ansi::graphics::colour::cyan,
         terminalpp::colour(),
         terminalpp::ansi::graphics::intensity::bold};
     terminalpp::attribute *current_attribute = &lowlight_attribute;
+
+    void redraw_frame()
+    {
+        auto size = self.get_size();
+        auto north_beam_region = munin::rectangle{{0,0}, {size.width, 1}};
+        auto south_beam_region = munin::rectangle{{0, size.height - 1}, {size.width, 1}};
+        auto west_beam_region  = munin::rectangle{{0, 1}, {1, size.height - 2}};
+        auto east_beam_region  = munin::rectangle{{size.width - 1, 1}, {1, size.height - 2}};
+
+        self.on_redraw({
+            north_beam_region, south_beam_region, west_beam_region, east_beam_region
+        });
+    }
+    
+    void evaluate_focus(std::shared_ptr<component> const &associated_component)
+    {
+        auto *old_attribute = current_attribute;
+        
+        current_attribute = associated_component->has_focus()
+                          ? &highlight_attribute
+                          : &lowlight_attribute;
+                          
+        if (current_attribute != old_attribute)
+        {
+            redraw_frame();
+        }
+    }
 };
 
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
 solid_frame::solid_frame()
-  : pimpl_(std::make_shared<impl>())
+  : pimpl_(std::make_shared<impl>(*this))
 {
     auto &attr = pimpl_->current_attribute;
     
@@ -78,19 +111,17 @@ void solid_frame::set_lowlight_attribute(
 void solid_frame::highlight_on_focus(
     std::shared_ptr<component> const &associated_component)
 {
-    auto const evaluate_focus = 
-        [this, wp = std::weak_ptr<component>(associated_component)]
+    auto evaluate_focus = 
+        [this, wp = std::weak_ptr<component>(associated_component)]()
         {
-            std::shared_ptr<component> associated_component(wp.lock());
-
-            if (associated_component)
+            std::shared_ptr<component> comp(wp);
+            
+            if (comp)
             {
-                pimpl_->current_attribute = associated_component->has_focus()
-                                          ? &pimpl_->highlight_attribute
-                                          : &pimpl_->lowlight_attribute;
+                pimpl_->evaluate_focus(comp);
             }
         };
-
+        
     associated_component->on_focus_set.connect(evaluate_focus);
     associated_component->on_focus_lost.connect(evaluate_focus);
     evaluate_focus();

--- a/src/solid_frame.cpp
+++ b/src/solid_frame.cpp
@@ -24,14 +24,27 @@ struct solid_frame::impl
     void redraw_frame()
     {
         auto size = self.get_size();
-        auto north_beam_region = munin::rectangle{{0,0}, {size.width, 1}};
-        auto south_beam_region = munin::rectangle{{0, size.height - 1}, {size.width, 1}};
-        auto west_beam_region  = munin::rectangle{{0, 1}, {1, size.height - 2}};
-        auto east_beam_region  = munin::rectangle{{size.width - 1, 1}, {1, size.height - 2}};
-
-        self.on_redraw({
-            north_beam_region, south_beam_region, west_beam_region, east_beam_region
-        });
+        
+        if (size.width > 2 && size.height > 2)
+        {
+            // Here we individually pick out the frame edges and redraw them.
+            auto north_beam_region = munin::rectangle{{0,0}, {size.width, 1}};
+            auto south_beam_region = munin::rectangle{{0, size.height - 1}, {size.width, 1}};
+            auto west_beam_region  = munin::rectangle{{0, 1}, {1, size.height - 2}};
+            auto east_beam_region  = munin::rectangle{{size.width - 1, 1}, {1, size.height - 2}};
+    
+            self.on_redraw({
+                north_beam_region, south_beam_region, west_beam_region, east_beam_region
+            });
+        }
+        else
+        {
+            // But if only our border is showing, then the redraw region is
+            // the complete frame area.
+            self.on_redraw({
+                {{0, 0}, size}
+            });
+        }
     }
     
     void evaluate_focus(std::shared_ptr<component> const &associated_component)

--- a/src/titled_frame.cpp
+++ b/src/titled_frame.cpp
@@ -39,16 +39,26 @@ struct titled_frame::impl
     void redraw_frame()
     {
         auto size = self.get_size();
-        auto northwest_beam_region = rectangle{{0, 0}, {2, 1}};
+        auto northwest_beam_region = size.width > 4
+          ? rectangle{{0, 0}, {2, 1}}
+          : rectangle{{0, 0}, {size.width, 1}};
         
         auto skipped_section_width = 3 + title->get_size().width + 1;
         auto northeast_beam_region = rectangle{
             {skipped_section_width, 0},
             {size.width - (skipped_section_width), 1}};
         
-        auto south_beam_region = rectangle{{0, size.height - 1}, {size.width, 1}};
-        auto west_beam_region  = rectangle{{0, 1}, {1, size.height - 2}};
-        auto east_beam_region  = rectangle{{size.width - 1, 1}, {1, size.height - 2}};
+        auto south_beam_region = size.height > 1
+          ? rectangle{{0, size.height - 1}, {size.width, 1}}
+          : rectangle{};
+          
+        auto west_beam_region  = size.height > 2
+          ? rectangle{{0, 1}, {1, size.height - 2}}
+          : rectangle{};
+          
+        auto east_beam_region  = size.height > 2
+          ? rectangle{{size.width - 1, 1}, {1, size.height - 2}}
+          : rectangle{};
 
         self.on_redraw({
             northwest_beam_region, northeast_beam_region,

--- a/src/titled_frame.cpp
+++ b/src/titled_frame.cpp
@@ -8,26 +8,68 @@ namespace munin {
 
 struct titled_frame::impl
 {
+    impl(titled_frame &self)
+      : self(self)
+    {
+    }
+    
+    titled_frame &self;
+    std::shared_ptr<image> title;
     terminalpp::attribute lowlight_attribute;
     terminalpp::attribute highlight_attribute = {
         terminalpp::ansi::graphics::colour::cyan,
         terminalpp::colour(),
         terminalpp::ansi::graphics::intensity::bold};
     terminalpp::attribute *current_attribute = &lowlight_attribute;
+
+    void evaluate_focus(std::shared_ptr<component> const &associated_component)
+    {
+        auto *old_attribute = current_attribute;
+        
+        current_attribute = associated_component->has_focus()
+                          ? &highlight_attribute
+                          : &lowlight_attribute;
+                          
+        if (old_attribute != current_attribute)
+        {
+            redraw_frame();
+        }
+    }
+
+    void redraw_frame()
+    {
+        auto size = self.get_size();
+        auto northwest_beam_region = rectangle{{0, 0}, {2, 1}};
+        
+        auto skipped_section_width = 3 + title->get_size().width + 1;
+        auto northeast_beam_region = rectangle{
+            {skipped_section_width, 0},
+            {size.width - (skipped_section_width), 1}};
+        
+        auto south_beam_region = rectangle{{0, size.height - 1}, {size.width, 1}};
+        auto west_beam_region  = rectangle{{0, 1}, {1, size.height - 2}};
+        auto east_beam_region  = rectangle{{size.width - 1, 1}, {1, size.height - 2}};
+
+        self.on_redraw({
+            northwest_beam_region, northeast_beam_region,
+            south_beam_region, west_beam_region, east_beam_region
+        });
+    }
 };
 
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
 titled_frame::titled_frame(terminalpp::string const &title)
-  : pimpl_(std::make_shared<impl>())
+  : pimpl_(std::make_shared<impl>(*this))
 {
     auto &attr = pimpl_->current_attribute;
+    pimpl_->title = make_image(title);
     
     auto title_piece = view(
         make_compass_layout(),
         make_fill(' '), compass_layout::heading::west,
-        make_image(title), compass_layout::heading::centre,
+        pimpl_->title, compass_layout::heading::centre,
         make_fill(' '), compass_layout::heading::east);
         
     auto title_banner = view(
@@ -100,9 +142,7 @@ void titled_frame::highlight_on_focus(
 
             if (associated_component)
             {
-                pimpl_->current_attribute = associated_component->has_focus()
-                                          ? &pimpl_->highlight_attribute
-                                          : &pimpl_->lowlight_attribute;
+                pimpl_->evaluate_focus(associated_component);
             }
         };
 

--- a/test/include/redraw.hpp
+++ b/test/include/redraw.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <munin/rectangle.hpp>
+#include <vector>
+
+void assert_equivalent_redraw_regions(
+    std::vector<munin::rectangle> const &lhs,
+    std::vector<munin::rectangle> const &rhs);

--- a/test/src/container/container_redraw_test.cpp
+++ b/test/src/container/container_redraw_test.cpp
@@ -1,4 +1,5 @@
 #include "container_test.hpp"
+#include "redraw.hpp"
 
 using testing::Return;
 
@@ -11,8 +12,7 @@ TEST_F(a_container_with_one_component, requests_redraws_relative_to_component_po
         [](auto const &redraw_regions)
         {
             static auto const expected_redraw_region = munin::rectangle{{2, 3}, {10,5}};
-            ASSERT_EQ(1u, redraw_regions.size());
-            ASSERT_EQ(expected_redraw_region, redraw_regions[0]);
+            assert_equivalent_redraw_regions(redraw_regions, {expected_redraw_region});
         });
         
     EXPECT_CALL(*component, do_get_position())

--- a/test/src/redraw.cpp
+++ b/test/src/redraw.cpp
@@ -1,0 +1,53 @@
+#include "redraw.hpp"
+#include <numeric>
+#include <gtest/gtest.h>
+
+static terminalpp::extent calculate_bounds(
+    std::vector<munin::rectangle> const &regions)
+{
+    return std::accumulate(
+        regions.begin(),
+        regions.end(),
+        terminalpp::extent{},
+        [](auto &bounds, auto const &region)
+        {
+            bounds.width = std::max(bounds.width, region.origin.x + region.size.width);
+            bounds.height = std::max(bounds.height, region.origin.y + region.size.height);
+            return bounds;
+        });
+}
+
+static std::vector<bool> create_redraw_map(
+    std::vector<munin::rectangle> const &regions)
+{
+    auto extent = calculate_bounds(regions);
+    std::vector<bool> redraw_map(extent.width * extent.height);
+    
+    for(auto const &region : regions)
+    {
+        for (auto row = region.origin.y; row < region.origin.y + region.size.height; ++row)
+        {
+            for (auto col = region.origin.x; col < region.origin.x + region.size.width; ++col)
+            {
+                redraw_map[(row * extent.width) + col] = true;
+            }
+        }
+    }
+    
+    return redraw_map;
+}
+
+void assert_equivalent_redraw_regions(
+    std::vector<munin::rectangle> const &lhs,
+    std::vector<munin::rectangle> const &rhs)
+{
+    auto const lhs_bounds = calculate_bounds(lhs);
+    auto const rhs_bounds = calculate_bounds(rhs);
+
+    ASSERT_EQ(lhs_bounds, rhs_bounds); 
+
+    auto const lhs_map = create_redraw_map(lhs);
+    auto const rhs_map = create_redraw_map(rhs);
+    
+    ASSERT_EQ(lhs_map, rhs_map);
+}

--- a/test/src/solid_frame/solid_frame_test.cpp
+++ b/test/src/solid_frame/solid_frame_test.cpp
@@ -1,5 +1,6 @@
 #include "mock/component.hpp"
 #include "mock/render_surface_capabilities.hpp"
+#include "redraw.hpp"
 #include <munin/solid_frame.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/string.hpp>
@@ -154,6 +155,7 @@ protected :
         frame_.highlight_on_focus(comp_);
         ON_CALL(*comp_, do_has_focus())
             .WillByDefault(Return(true));
+        comp_->on_focus_set();
     }
     
     std::shared_ptr<mock_component> comp_ = make_mock_component();
@@ -205,6 +207,34 @@ TEST_F(a_solid_frame_with_an_associated_unfocussed_component, when_focussed_draw
     ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[1][3]);
     ASSERT_EQ(terminalpp::element(horizontal_beam,     highlight_attribute), canvas[2][3]);
     ASSERT_EQ(terminalpp::element(bottom_right_corner, highlight_attribute), canvas[3][3]);
+}
+
+TEST_F(a_solid_frame_with_an_associated_unfocussed_component, redraws_when_associated_component_gains_focus)
+{
+    frame_.set_size({4, 4});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0, 0}, {4, 1}},
+      munin::rectangle{{0, 0}, {1, 4}},
+      munin::rectangle{{3, 0}, {1, 4}},
+      munin::rectangle{{0, 3}, {4, 1}}
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 }
 
 TEST_F(a_solid_frame_with_an_associated_focussed_component, when_unfocussed_draws_a_lowlit_border)
@@ -265,3 +295,30 @@ TEST_F(a_solid_frame_with_an_associated_focussed_component, can_have_a_custom_hi
     ASSERT_EQ(terminalpp::element(bottom_right_corner, custom_highlight), canvas[3][3]);
 }
 
+TEST_F(a_solid_frame_with_an_associated_focussed_component, redraws_when_associated_component_loses_focus)
+{
+    frame_.set_size({4, 4});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(false));
+    comp_->on_focus_lost();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0, 0}, {4, 1}},
+      munin::rectangle{{0, 0}, {1, 4}},
+      munin::rectangle{{3, 0}, {1, 4}},
+      munin::rectangle{{0, 3}, {4, 1}}
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+}

--- a/test/src/solid_frame/solid_frame_test.cpp
+++ b/test/src/solid_frame/solid_frame_test.cpp
@@ -237,6 +237,39 @@ TEST_F(a_solid_frame_with_an_associated_unfocussed_component, redraws_when_assoc
     assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 }
 
+TEST_F(a_solid_frame_with_an_associated_unfocussed_component, redraws_a_reduced_amount_when_associated_component_gains_focus_when_small)
+{
+    frame_.set_size({1, 1});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0, 0}, {1, 1}},
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+    
+    for (auto region : redraw_regions)
+    {
+        ASSERT_GE(region.origin.x, 0);
+        ASSERT_GE(region.origin.y, 0);
+        ASSERT_GE(region.size.width, 0);
+        ASSERT_GE(region.size.height, 0);
+    }
+}
+
 TEST_F(a_solid_frame_with_an_associated_focussed_component, when_unfocussed_draws_a_lowlit_border)
 {
     frame_.set_size({4, 4});

--- a/test/src/titled_frame/titled_frame_test.cpp
+++ b/test/src/titled_frame/titled_frame_test.cpp
@@ -387,6 +387,132 @@ TEST_F(a_titled_frame_with_an_associated_unfocussed_component, redraws_when_asso
     assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 }
 
+TEST_F(a_titled_frame_with_an_associated_unfocussed_component, redraws_a_reduced_amount_when_associated_component_gains_focus_when_short)
+{
+    frame_.set_size({11, 2});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0,  0}, {2,  1}},
+      munin::rectangle{{9,  0}, {2,  1}},
+      munin::rectangle{{0,  1}, {11, 1}},
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+
+    for (auto region : redraw_regions)
+    {
+        ASSERT_GE(region.origin.x, 0);
+        ASSERT_GE(region.origin.y, 0);
+        ASSERT_GE(region.size.width, 0);
+        ASSERT_GE(region.size.height, 0);
+    }
+}
+
+TEST_F(a_titled_frame_with_an_associated_unfocussed_component, redraws_a_reduced_amount_when_associated_component_gains_focus_when_only_title_is_showing)
+{
+    frame_.set_size({11, 1});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0,  0}, {2,  1}},
+      munin::rectangle{{9,  0}, {2,  1}},
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+
+    for (auto region : redraw_regions)
+    {
+        ASSERT_GE(region.origin.x, 0);
+        ASSERT_GE(region.origin.y, 0);
+        ASSERT_GE(region.size.width, 0);
+        ASSERT_GE(region.size.height, 0);
+    }
+}
+
+TEST_F(a_titled_frame_with_an_associated_unfocussed_component, redraws_a_reduced_amount_when_associated_component_gains_focus_and_title_is_clipped)
+{
+    frame_.set_size({9, 3});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0,  0}, {2,  1}},
+      munin::rectangle{{7,  0}, {2,  1}},
+      munin::rectangle{{0,  0}, {1,  3}},
+      munin::rectangle{{8,  0}, {1,  3}},
+      munin::rectangle{{0,  2}, {9,  1}}
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+}
+
+TEST_F(a_titled_frame_with_an_associated_unfocussed_component, redraws_a_reduced_amount_when_associated_component_gains_focus_and_frame_is_thin)
+{
+    frame_.set_size({4, 3});
+    
+    int redraw_count = 0;
+    std::vector<munin::rectangle> redraw_regions;
+    frame_.on_redraw.connect(
+        [&redraw_count, &redraw_regions](auto const &regions)
+        {
+            ++redraw_count;
+            redraw_regions = regions;
+        });
+    
+    ON_CALL(*comp_, do_has_focus())
+        .WillByDefault(Return(true));
+    comp_->on_focus_set();
+    
+    std::vector<munin::rectangle> const expected_redraw_regions = {
+      munin::rectangle{{0,  0}, {4,  1}},
+      munin::rectangle{{0,  0}, {1,  3}},
+      munin::rectangle{{3,  0}, {1,  3}},
+      munin::rectangle{{0,  2}, {4,  1}}
+    };
+    
+    ASSERT_EQ(1, redraw_count);
+    assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
+}
+
 TEST_F(a_titled_frame_with_an_associated_focussed_component, when_unfocussed_draws_a_lowlit_border)
 {
     auto const size = terminalpp::extent{11, 3};


### PR DESCRIPTION
Ensure that solid and title frames redraw themselves correctly as focus is gained and lost on the associated component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/119)
<!-- Reviewable:end -->
