### PR TITLE
Compass layout preferred size#125

### DIFF
--- a/src/compass_layout.cpp
+++ b/src/compass_layout.cpp
@@ -169,27 +169,31 @@ terminalpp::extent compass_layout::do_get_preferred_size(
             case heading::north :
                 // fall-through
             case heading::south :
-                unused_size.width = std::max(
-                    unused_size.width,
-                    comp_preferred_size.width - preferred_size.width);
-                    
-                preferred_size.width = std::max(
-                    preferred_size.width,
-                    comp_preferred_size.width);
-                preferred_size.height += comp_preferred_size.height;    
+                preferred_size.width += std::max(
+                    comp_preferred_size.width - unused_size.width, 0);
+                unused_size.width += std::max(
+                    comp_preferred_size.width - unused_size.width, 0);
+                
+                preferred_size.height += std::max(
+                    comp_preferred_size.height - unused_size.height, 0);
+                unused_size.height -= std::min(
+                    unused_size.height,
+                    comp_preferred_size.height);
                 break;
                 
             case heading::west :
                 // fall-through
             case heading::east :
-                unused_size.height = std::max(
-                    unused_size.height,
-                    comp_preferred_size.height - preferred_size.height);
-                    
-                preferred_size.width += comp_preferred_size.width;    
-                preferred_size.height = std::max(
-                    preferred_size.height,
-                    comp_preferred_size.height);
+                preferred_size.height += std::max(
+                    comp_preferred_size.height - unused_size.height, 0);
+                unused_size.height += std::max(
+                    comp_preferred_size.height - unused_size.height, 0);
+                
+                preferred_size.width += std::max(
+                    comp_preferred_size.width - unused_size.width, 0);
+                unused_size.width -= std::min(
+                    unused_size.width,
+                    comp_preferred_size.width);
               break;
         }
     }

--- a/test/src/compass_layout/compass_layout_test.cpp
+++ b/test/src/compass_layout/compass_layout_test.cpp
@@ -6,10 +6,11 @@
 using testing::Return;
 using testing::ValuesIn;
 
-const static auto north = boost::any{munin::compass_layout::heading::north};
-const static auto south = boost::any{munin::compass_layout::heading::south};
-const static auto east  = boost::any{munin::compass_layout::heading::east};
-const static auto west  = boost::any{munin::compass_layout::heading::west};
+const static auto north  = boost::any{munin::compass_layout::heading::north};
+const static auto south  = boost::any{munin::compass_layout::heading::south};
+const static auto east   = boost::any{munin::compass_layout::heading::east};
+const static auto west   = boost::any{munin::compass_layout::heading::west};
+const static auto centre = boost::any{munin::compass_layout::heading::centre};
 
 TEST(compass_layout_test, reports_attributes_as_json)
 {
@@ -520,45 +521,235 @@ INSTANTIATE_TEST_CASE_P(
             }},
             { 3, 4 },
             { 3, 4 }
-        }
-    })
-);
+        },
 
-#if 0
-INSTANTIATE_TEST_CASE_P(
-    west_and_east_consume_allocated_width,
-    compass_layouts,
-    ValuesIn(
-    {
+        /*
+                 +-+
+                 | |
+                 |E|
+                 | |
+                 | |
+        +--------+-+
+        |    S     |
+        +----------+
+        */
         compass_layout_test_data {{
             compass_layout_component_data {
-                { 3, 3 },
-                boost::any(munin::compass_layout::heading::north),
-                { { 0, 0 }, { 3, 3 } }
-            },
-            compass_layout_component_data {
-                { 3, 3 },
-                boost::any(munin::compass_layout::heading::south),
-                { { 0, 6 }, { 3, 3 } }
+                { 3, 1 },
+                south,
+                { { 0, 3 }, { 3, 1 } }
             },
             compass_layout_component_data {
                 { 1, 3 },
-                boost::any(munin::compass_layout::heading::east),
-                { { 3, 3 }, { 1, 3 } }
-            },
-            compass_layout_component_data {
-                { 1, 3 },
-                boost::any(munin::compass_layout::heading::west),
-                { { 0, 3 }, { 1, 3 } }
-            },
-            compass_layout_component_data {
-                { 0, 0 },
-                boost::any(munin::compass_layout::heading::centre),
-                { { 1, 1 }, { 1, 1 } }
+                east,
+                { { 2, 0 }, { 1, 3 } }
             }},
-            { 3, 9 },
-            { 3, 9 }
+            { 3, 4 },
+            { 3, 4 }
+        },
+
+        /*
+        +-+
+        | |
+        |W|
+        | |
+        | |
+        +-+--------+
+        |    S     |
+        +----------+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 3, 1 },
+                south,
+                { { 0, 3 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 1, 3 },
+                west,
+                { { 0, 0 }, { 1, 3 } }
+            }},
+            { 3, 4 },
+            { 3, 4 }
+        },
+
+        /*
+        +----------+
+        |    N     |
+        +-+--------+
+        | |
+        | |
+        |W|
+        | |
+        +-+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 1, 3 },
+                west,
+                { { 0, 1 }, { 1, 3 } }
+            }},
+            { 3, 4 },
+            { 3, 4 }
+        },
+
+        /*
+             +-----+-+
+             |  N  | |
+             +-----+ |
+                   | |
+             SPACE!|E|
+                   | |
+                   +-+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 3, 0 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            }},
+            { 4, 3 },
+            { 4, 3 }
+        },
+
+        /*
+        Adding a small centre component will grow to fit the available space.
+
+             +-----+-+
+             |  N  | |
+             +-+---+ |
+             |C|   | |
+             +-+   |E|
+             |  \_ | |
+             +----\+-+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 3, 0 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 1, 1 },
+                centre,
+                { { 0, 1 }, { 3, 2 } }
+            }},
+            { 4, 3 },
+            { 4, 3 }
+        },
+
+        /*
+        Adding a perfectly fitting centre component fill the available space.
+
+             +-----+-+
+             |  N  | |
+             +-----+ |
+             |     | |
+             |  C  |E|
+             |     | |
+             +-----+-+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 3, 0 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 3, 2 },
+                centre,
+                { { 0, 1 }, { 3, 2 } }
+            }},
+            { 4, 3 },
+            { 4, 3 }
+        },
+
+        /*
+        Adding a large centre component shrink into the available space,
+        even if its preferred size is large.
+
+           +-+-----+-+
+           |\|  N  | |
+           | +-----+ |
+           | |     | |
+           | |  C  |E|
+           | |     | |
+           | +-----+-+
+           |/       \|
+           +---------+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 3, 0 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 5, 5 },
+                centre,
+                { { 0, 1 }, { 3, 2 } }
+            }},
+            { 4, 3 },
+            { 6, 6 }
+        },
+
+        /*
+        Finally, a large centre component causes other components to stretch 
+        into the available space, if it is given.
+
+           +-+-----+-+
+           |-|  N  | |
+           +-+-----+ |
+           |       | |
+           |    C  |E|
+           |       | |
+           |       +-+
+           |       |||
+           +-------+-+
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 5, 0 }, { 1, 6 } }
+            },
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 5, 1 } }
+            },
+            compass_layout_component_data {
+                { 5, 5 },
+                centre,
+                { { 0, 1 }, { 5, 5 } }
+            }},
+            { 6, 6 },
+            { 6, 6 }
         },
     })
 );
-#endif

--- a/test/src/compass_layout/compass_layout_test.cpp
+++ b/test/src/compass_layout/compass_layout_test.cpp
@@ -481,3 +481,61 @@ INSTANTIATE_TEST_CASE_P(
         }
     })
 );
+
+#if 0
+INSTANTIATE_TEST_CASE_P(
+    west_and_east_consume_allocated_width,
+    compass_layouts,
+    ValuesIn(
+    {
+    / *
+        +------------+
+        |+----------+|
+        ||    N     ||
+        |+--+----+--+|
+        ||     |    ||
+        ||     |    ||
+        ||W    |   E||
+        ||     |    ||
+        ||     |    ||
+        ||     |    ||
+        |+--+----+--+|
+        ||    S     ||
+        |+----------+|
+        +------------+
+    * /
+
+// TODO: FIXME: this is blatantly wrong, since this wouldn't produce the image
+// above (rather, N and S would be touching and W and E would be separated)
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 3, 3 },
+                boost::any(munin::compass_layout::heading::north),
+                { { 0, 0 }, { 3, 3 } }
+            },
+            compass_layout_component_data {
+                { 3, 3 },
+                boost::any(munin::compass_layout::heading::south),
+                { { 0, 6 }, { 3, 3 } }
+            },
+            compass_layout_component_data {
+                { 1, 3 },
+                boost::any(munin::compass_layout::heading::east),
+                { { 3, 3 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 1, 3 },
+                boost::any(munin::compass_layout::heading::west),
+                { { 0, 3 }, { 1, 3 } }
+            },
+            compass_layout_component_data {
+                { 0, 0 },
+                boost::any(munin::compass_layout::heading::centre),
+                { { 1, 1 }, { 1, 1 } }
+            }},
+            { 3, 9 },
+            { 3, 9 }
+        },
+    })
+);
+#endif

--- a/test/src/compass_layout/compass_layout_test.cpp
+++ b/test/src/compass_layout/compass_layout_test.cpp
@@ -6,6 +6,11 @@
 using testing::Return;
 using testing::ValuesIn;
 
+const static auto north = boost::any{munin::compass_layout::heading::north};
+const static auto south = boost::any{munin::compass_layout::heading::south};
+const static auto east  = boost::any{munin::compass_layout::heading::east};
+const static auto west  = boost::any{munin::compass_layout::heading::west};
+
 TEST(compass_layout_test, reports_attributes_as_json)
 {
     munin::compass_layout cl;
@@ -482,31 +487,49 @@ INSTANTIATE_TEST_CASE_P(
     })
 );
 
+INSTANTIATE_TEST_CASE_P(
+    compass_layouts_preserve_empty_space,
+    compass_layouts,
+    ValuesIn(
+    {
+        /*
+             L-shapes should preserve the associated empty space.
+             For example:
+             
+             +--------+
+             |    N   |
+             +------+-+
+                    | |
+                    |E|
+             SPACE! | |
+                    | |
+                    +-+
+                    
+             And rotations/permutations thereof.
+        */
+        compass_layout_test_data {{
+            compass_layout_component_data {
+                { 3, 1 },
+                north,
+                { { 0, 0 }, { 3, 1 } }
+            },
+            compass_layout_component_data {
+                { 1, 3 },
+                east,
+                { { 2, 1 }, { 1, 3 } }
+            }},
+            { 3, 4 },
+            { 3, 4 }
+        }
+    })
+);
+
 #if 0
 INSTANTIATE_TEST_CASE_P(
     west_and_east_consume_allocated_width,
     compass_layouts,
     ValuesIn(
     {
-    / *
-        +------------+
-        |+----------+|
-        ||    N     ||
-        |+--+----+--+|
-        ||     |    ||
-        ||     |    ||
-        ||W    |   E||
-        ||     |    ||
-        ||     |    ||
-        ||     |    ||
-        |+--+----+--+|
-        ||    S     ||
-        |+----------+|
-        +------------+
-    * /
-
-// TODO: FIXME: this is blatantly wrong, since this wouldn't produce the image
-// above (rather, N and S would be touching and W and E would be separated)
         compass_layout_test_data {{
             compass_layout_component_data {
                 { 3, 3 },


### PR DESCRIPTION
Fixed compass layout preferred sizes.  It not takes into account the amount of unused space left over, and can use this for spacing centre components.

Fixes #125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/127)
<!-- Reviewable:end -->
