### PR TITLE
Explicitly pinned Travis caches to $HOME directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ matrix:
 cache:
   - apt: true
   - directories:
-    - lcov
-    - .conan
+    - $HOME/lcov
+    - $HOME/.conan
 
 before_install:
 # Set up CC/CXX variables
@@ -98,9 +98,9 @@ before_install:
 before_script:
   - mkdir build || true
   - cd build
-  - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite
-  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-  - conan remote add kazdragon-conan https://api.bintray.com/conan/kazdragon/conan-public
+  - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite || true
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
+  - conan remote add kazdragon-conan https://api.bintray.com/conan/kazdragon/conan-public || true
   - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o munin:withTests=True -o munin:shared=$SHARED --build=missing
   - conan build -c ..
   - $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DMUNIN_SANITIZE=$SANITIZE -DMUNIN_COVERAGE=$COVERAGE ..


### PR DESCRIPTION
Removes about 1/3 of the time from Travis builds due to not having to download all those Conan packages (around 4-5 minutes).