### PR TITLE
Viewport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(munin
         include/munin/vertical_strip_layout.hpp
         include/munin/window.hpp
         include/munin/view.hpp
+        include/munin/viewport.hpp
     
         include/munin/detail/adaptive_fill.hpp
         include/munin/detail/algorithm.hpp
@@ -87,6 +88,7 @@ target_sources(munin
         src/toggle_button.cpp
         src/vertical_strip_layout.cpp
         src/window.cpp
+        src/viewport.cpp
     
         src/detail/adaptive_fill.cpp
         src/detail/algorithm.cpp
@@ -192,6 +194,7 @@ if (MUNIN_WITH_TESTS)
             test/src/toggle_button/toggle_button_test.cpp
             test/src/toggle_button/toggle_button_json_test.cpp
             test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
+            test/src/viewport/viewport_test.cpp
             test/src/window/window_json_test.cpp
             test/src/window/window_test.cpp
             test/src/window/window_repaint_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ if (MUNIN_WITH_TESTS)
             test/src/viewport/viewport_test.hpp
             test/src/viewport/viewport_test.cpp
             test/src/viewport/viewport_cursor_test.cpp
+            test/src/viewport/viewport_redraw_test.cpp
             test/src/viewport/viewport_size_test.cpp
             test/src/window/window_json_test.cpp
             test/src/window/window_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ if (MUNIN_WITH_TESTS)
             test/src/viewport/viewport_test.hpp
             test/src/viewport/viewport_test.cpp
             test/src/viewport/viewport_cursor_test.cpp
+            test/src/viewport/viewport_size_test.cpp
             test/src/window/window_json_test.cpp
             test/src/window/window_test.cpp
             test/src/window/window_repaint_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,9 @@ if (MUNIN_WITH_TESTS)
             test/src/toggle_button/toggle_button_test.cpp
             test/src/toggle_button/toggle_button_json_test.cpp
             test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
+            test/src/viewport/viewport_test.hpp
             test/src/viewport/viewport_test.cpp
+            test/src/viewport/viewport_cursor_test.cpp
             test/src/window/window_json_test.cpp
             test/src/window/window_test.cpp
             test/src/window/window_repaint_test.cpp

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -23,6 +23,13 @@ public:
     
 private:
     //* =====================================================================
+    /// \brief Called by set_size().  Derived classes must override this
+    /// function in order to set the size of the component in a custom
+    /// manner.
+    //* =====================================================================
+    void do_set_size(terminalpp::extent const &size) ;
+
+    //* =====================================================================
     /// \brief Called by get_preferred_size().  Derived classes must override
     /// this function in order to get the size of the component in a custom
     /// manner.

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "munin/basic_component.hpp"
+
+namespace munin {
+
+//* =========================================================================
+/// A component that tracks a subset of another component and shows only a
+/// section of it.
+//* =========================================================================
+class MUNIN_EXPORT viewport : public basic_component
+{
+public:
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    viewport(std::shared_ptr<component> tracked_component);
+    
+    //* =====================================================================
+    /// \brief Destructor
+    //* =====================================================================
+    ~viewport() override;
+    
+private:
+    //* =====================================================================
+    /// \brief Called by get_preferred_size().  Derived classes must override
+    /// this function in order to get the size of the component in a custom
+    /// manner.
+    //* =====================================================================
+    terminalpp::extent do_get_preferred_size() const override;
+
+    //* =====================================================================
+    /// \brief Called by draw().  Derived classes must override this function
+    /// in order to draw onto the passed canvas.  A component must only draw
+    /// the part of itself specified by the region.
+    ///
+    /// \param surface the surface on which the component should draw itself.
+    /// \param region the region relative to this component's origin that
+    /// should be drawn.
+    //* =====================================================================
+    void do_draw(
+        render_surface &surface,
+        terminalpp::rectangle const &region) const override;
+
+    //* =====================================================================
+    /// \brief Called by event().  Derived classes must override this
+    /// function in order to handle events in a custom manner.
+    //* =====================================================================
+    void do_event(boost::any const &event) override;
+
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+//* =========================================================================
+/// \brief Returns a newly created viewport.
+//* =========================================================================
+MUNIN_EXPORT
+std::shared_ptr<viewport> make_viewport(
+    std::shared_ptr<component> tracked_component);
+
+}

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -37,6 +37,13 @@ private:
     terminalpp::extent do_get_preferred_size() const override;
 
     //* =====================================================================
+    /// \brief Called by get_cursor_position().  Derived classes must
+    /// override this function in order to return the cursor position in
+    /// a custom manner.
+    //* =====================================================================
+    terminalpp::point do_get_cursor_position() const override;
+
+    //* =====================================================================
     /// \brief Called by draw().  Derived classes must override this function
     /// in order to draw onto the passed canvas.  A component must only draw
     /// the part of itself specified by the region.

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -18,6 +18,8 @@ struct viewport::impl
     {
         tracked_component_->on_preferred_size_changed.connect(
             [this]{on_tracked_component_preferred_size_changed();});
+        tracked_component_->on_cursor_position_changed.connect(
+            [this]{on_tracked_component_cursor_position_changed();});
     }
     
     // ======================================================================
@@ -26,6 +28,14 @@ struct viewport::impl
     auto get_preferred_size()
     {
         return tracked_component_->get_preferred_size();
+    }
+
+    // ======================================================================
+    // GET_CURSOR_POSITION
+    // ======================================================================
+    auto get_cursor_position()
+    {
+        return cursor_position_;
     }
 
     // ======================================================================
@@ -61,6 +71,20 @@ struct viewport::impl
     }
 private:
     // ======================================================================
+    // ON_TRACKED_COMPONENT_CURSOR_POSITION_CHANGED
+    // ======================================================================
+    void on_tracked_component_cursor_position_changed()
+    {
+        auto const old_cursor_position = cursor_position_;
+        cursor_position_ = tracked_component_->get_cursor_position();
+
+        if (old_cursor_position != cursor_position_)
+        {
+            self_.on_cursor_position_changed();
+        }
+    }
+
+    // ======================================================================
     // ON_TRACKED_COMPONENT_PREFERRED_SIZE_CHANGED
     // ======================================================================
     void on_tracked_component_preferred_size_changed()
@@ -71,6 +95,7 @@ private:
     
     viewport &self_;
     std::shared_ptr<component> tracked_component_;
+    terminalpp::point          cursor_position_;
 };
 
 // ==========================================================================
@@ -103,6 +128,14 @@ void viewport::do_set_size(terminalpp::extent const &size)
 terminalpp::extent viewport::do_get_preferred_size() const
 {
     return pimpl_->get_preferred_size();
+}
+
+// ==========================================================================
+// DO_GET_CURSOR_POSITION
+// ==========================================================================
+terminalpp::point viewport::do_get_cursor_position() const
+{
+    return pimpl_->get_cursor_position();
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -74,11 +74,11 @@ struct viewport::impl
         
         tracked_component_->set_size(tracked_component_size);
     }
-private:
+
     // ======================================================================
-    // ON_TRACKED_COMPONENT_CURSOR_POSITION_CHANGED
+    // UPDATE_VIEWPORT_POSITION
     // ======================================================================
-    void on_tracked_component_cursor_position_changed()
+    void update_viewport_position()
     {
         auto const old_cursor_position = cursor_position_;
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
@@ -119,6 +119,15 @@ private:
         }
     }
 
+private:
+    // ======================================================================
+    // ON_TRACKED_COMPONENT_CURSOR_POSITION_CHANGED
+    // ======================================================================
+    void on_tracked_component_cursor_position_changed()
+    {
+        update_viewport_position();
+    }
+
     // ======================================================================
     // ON_TRACKED_COMPONENT_PREFERRED_SIZE_CHANGED
     // ======================================================================
@@ -156,6 +165,7 @@ void viewport::do_set_size(terminalpp::extent const &size)
 {
     basic_component::do_set_size(size);
     pimpl_->update_tracked_component_size();
+    pimpl_->update_viewport_position();
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -86,15 +86,23 @@ private:
 
         if (tracked_cursor_position.x >= viewport_position_.x + viewport_size.width)
         {
-            // cursor has scrolled off to the east of the viewport, so the 
+            // Cursor has scrolled off to the east of the viewport, so the 
             // viewport x position needs to change just enough to keep the
             // cursor on the screen.
             viewport_position_.x = (tracked_cursor_position.x - viewport_size.width) + 1;
         }
 
+        if (tracked_cursor_position.y >= viewport_position_.y + viewport_size.height)
+        {
+            // Cursor has scrolled off to the south of the viewport, so the
+            // viewport y position needs to change just enough to keep the
+            // cursor on the screen.
+            viewport_position_.y = (tracked_cursor_position.y - viewport_size.height) + 1;
+        }
+
         cursor_position_ = {
             tracked_cursor_position.x - viewport_position_.x,
-            tracked_cursor_position.y
+            tracked_cursor_position.y - viewport_position_.y
         };
 
         if (old_cursor_position != cursor_position_)

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -9,6 +9,7 @@ namespace munin {
 // ==========================================================================
 struct viewport::impl
 {
+    std::shared_ptr<component> tracked_component_;
 };
 
 // ==========================================================================
@@ -17,6 +18,9 @@ struct viewport::impl
 viewport::viewport(std::shared_ptr<component> tracked_component)
   : pimpl_(boost::make_unique<impl>())
 {
+    pimpl_->tracked_component_ = std::move(tracked_component);
+    pimpl_->tracked_component_->on_preferred_size_changed.connect(
+        on_preferred_size_changed);
 }
 
 // ==========================================================================
@@ -29,7 +33,7 @@ viewport::~viewport() = default;
 // ==========================================================================
 terminalpp::extent viewport::do_get_preferred_size() const
 {
-    return {};
+    return pimpl_->tracked_component_->get_preferred_size();
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -36,11 +36,10 @@ struct viewport::impl
         return tracked_component_->event(ev);
     }
     
-private:
     // ======================================================================
-    // ON_TRACKED_COMPONENT_PREFERRED_SIZE_CHANGED
+    // UPDATE_TRACKED_COMPONENT_SIZE
     // ======================================================================
-    void on_tracked_component_preferred_size_changed()
+    void update_tracked_component_size()
     {
         auto const preferred_size = tracked_component_->get_preferred_size();
         auto const viewport_size = self_.get_size();
@@ -51,6 +50,14 @@ private:
         };
         
         tracked_component_->set_size(tracked_component_size);
+    }
+private:
+    // ======================================================================
+    // ON_TRACKED_COMPONENT_PREFERRED_SIZE_CHANGED
+    // ======================================================================
+    void on_tracked_component_preferred_size_changed()
+    {
+        update_tracked_component_size();
         self_.on_preferred_size_changed();
     }
     
@@ -72,6 +79,15 @@ viewport::viewport(std::shared_ptr<component> tracked_component)
 // DESTRUCTOR
 // ==========================================================================
 viewport::~viewport() = default;
+
+// ==========================================================================
+// DO_SET_SIZE
+// ==========================================================================
+void viewport::do_set_size(terminalpp::extent const &size)
+{
+    basic_component::do_set_size(size);
+    pimpl_->update_tracked_component_size();
+}
 
 // ==========================================================================
 // DO_GET_PREFERRED_SIZE

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -28,6 +28,14 @@ struct viewport::impl
         return tracked_component_->get_preferred_size();
     }
 
+    // ======================================================================
+    // EVENT
+    // ======================================================================
+    auto event(boost::any const& ev)
+    {
+        return tracked_component_->event(ev);
+    }
+    
 private:
     // ======================================================================
     // ON_TRACKED_COMPONENT_PREFERRED_SIZE_CHANGED
@@ -79,6 +87,7 @@ void viewport::do_draw(
 // ==========================================================================
 void viewport::do_event(boost::any const &event)
 {
+    pimpl_->event(event);
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -81,6 +81,7 @@ struct viewport::impl
     void update_viewport_position()
     {
         auto const old_cursor_position = cursor_position_;
+        auto const old_viewport_position = viewport_position_;
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
         auto const viewport_size = self_.get_size();
 
@@ -113,6 +114,11 @@ struct viewport::impl
             tracked_cursor_position.y - viewport_position_.y
         };
 
+        if (old_viewport_position != viewport_position_)
+        {
+            self_.on_redraw({terminalpp::rectangle{self_.get_position(), self_.get_size()}});
+        }
+        
         if (old_cursor_position != cursor_position_)
         {
             self_.on_cursor_position_changed();

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -84,19 +84,23 @@ private:
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
         auto const viewport_size = self_.get_size();
 
-        if (tracked_cursor_position.x >= viewport_position_.x + viewport_size.width)
+        // Check to see if the tracked cursor has scrolled off an edge of the
+        // viewport.  If so, then the viewport position must change just enough
+        // to keep the cursor within the visual area.
+        if (tracked_cursor_position.x < viewport_position_.x)
         {
-            // Cursor has scrolled off to the east of the viewport, so the 
-            // viewport x position needs to change just enough to keep the
-            // cursor on the screen.
+            // Cursor has scrolled off to the west of the viewport.
+            viewport_position_.x = tracked_cursor_position.x;
+        }
+        else if (tracked_cursor_position.x >= viewport_position_.x + viewport_size.width)
+        {
+            // Cursor has scrolled off to the east of the viewport.
             viewport_position_.x = (tracked_cursor_position.x - viewport_size.width) + 1;
         }
 
         if (tracked_cursor_position.y >= viewport_position_.y + viewport_size.height)
         {
-            // Cursor has scrolled off to the south of the viewport, so the
-            // viewport y position needs to change just enough to keep the
-            // cursor on the screen.
+            // Cursor has scrolled off to the south of the viewport.
             viewport_position_.y = (tracked_cursor_position.y - viewport_size.height) + 1;
         }
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -98,7 +98,11 @@ private:
             viewport_position_.x = (tracked_cursor_position.x - viewport_size.width) + 1;
         }
 
-        if (tracked_cursor_position.y >= viewport_position_.y + viewport_size.height)
+        if (tracked_cursor_position.y < viewport_position_.y)
+        {
+            viewport_position_.y = tracked_cursor_position.y;
+        }
+        else if (tracked_cursor_position.y >= viewport_position_.y + viewport_size.height)
         {
             // Cursor has scrolled off to the south of the viewport.
             viewport_position_.y = (tracked_cursor_position.y - viewport_size.height) + 1;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1,0 +1,60 @@
+#include "munin/viewport.hpp"
+#include <boost/make_unique.hpp>
+#include <utility>
+
+namespace munin {
+
+// ==========================================================================
+// VIEWPORT::IMPLEMENTATION STRUCTURE
+// ==========================================================================
+struct viewport::impl
+{
+};
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+viewport::viewport(std::shared_ptr<component> tracked_component)
+  : pimpl_(boost::make_unique<impl>())
+{
+}
+
+// ==========================================================================
+// DESTRUCTOR
+// ==========================================================================
+viewport::~viewport() = default;
+
+// ==========================================================================
+// DO_GET_PREFERRED_SIZE
+// ==========================================================================
+terminalpp::extent viewport::do_get_preferred_size() const
+{
+    return {};
+}
+
+// ==========================================================================
+// DO_DRAW
+// ==========================================================================
+void viewport::do_draw(
+    render_surface &surface,
+    terminalpp::rectangle const &region) const
+{
+}
+
+// ==========================================================================
+// DO_EVENT
+// ==========================================================================
+void viewport::do_event(boost::any const &event)
+{
+}
+
+// ==========================================================================
+// MAKE_VIEWPORT
+// ==========================================================================
+std::shared_ptr<viewport> make_viewport(
+    std::shared_ptr<component> tracked_component)
+{
+    return std::make_shared<viewport>(std::move(tracked_component));
+}
+
+}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -29,6 +29,14 @@ struct viewport::impl
     }
 
     // ======================================================================
+    // DRAW
+    // ======================================================================
+    void draw(render_surface& surface, terminalpp::rectangle const &region)
+    {
+        tracked_component_->draw(surface, region);
+    }
+
+    // ======================================================================
     // EVENT
     // ======================================================================
     auto event(boost::any const& ev)
@@ -104,6 +112,7 @@ void viewport::do_draw(
     render_surface &surface,
     terminalpp::rectangle const &region) const
 {
+    pimpl_->draw(surface, region);
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -42,7 +42,15 @@ private:
     // ======================================================================
     void on_tracked_component_preferred_size_changed()
     {
-        tracked_component_->set_size(tracked_component_->get_preferred_size());
+        auto const preferred_size = tracked_component_->get_preferred_size();
+        auto const viewport_size = self_.get_size();
+        
+        auto const tracked_component_size = terminalpp::extent{
+            std::max(preferred_size.width, viewport_size.width),
+            std::max(preferred_size.height, viewport_size.height)
+        };
+        
+        tracked_component_->set_size(tracked_component_size);
         self_.on_preferred_size_changed();
     }
     

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -168,5 +168,15 @@ INSTANTIATE_TEST_CASE_P(
         viewport_cursor_test_data{
             {0, 5}, {0, 2}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
         },
+
+        // Cursor is moved north-west of the visual zone.
+        viewport_cursor_test_data{
+            {5, 5}, {2, 2}, {1, 1}, {0, 0}, {{1, 1}, {3, 3}}
+        },
+
+        // Cursor is moved north-east of the visual zone.
+        viewport_cursor_test_data{
+            {0, 5}, {0, 2}, {5, 0}, {2, 0}, {{3, 0}, {3, 3}}
+        },
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -20,38 +20,8 @@ using viewport_cursor_test_data = std::tuple<
     terminalpp::rectangle  // expected tracked draw area
 >;
 
-class viewport_cursor_tracking_test
-  : public a_viewport_with_mock_tracked_component,
-    public testing::TestWithParam<viewport_cursor_test_data>
-{
-protected:
-    viewport_cursor_tracking_test()
-    {
-        static auto constexpr tracked_component_preferred_size = terminalpp::extent{6, 6};
-        static auto constexpr viewport_size = terminalpp::extent{3, 3};
-
-        // Set the preferred size of the tracked component.  It is tested elsewhere that
-        // a viewport allows the tracked component its preferred size.
-        ON_CALL(*tracked_component_, do_get_preferred_size())
-            .WillByDefault(Return(tracked_component_preferred_size));
-        tracked_component_->on_preferred_size_changed();
-
-        // Mock the cursor position of the tracked component so that it does what it
-        // is told and announces it to the viewport.
-        ON_CALL(*tracked_component_, do_set_cursor_position(_))
-            .WillByDefault(Invoke([this](auto const &pos) { 
-                tracked_cursor_position_ = pos;
-                tracked_component_->on_cursor_position_changed();
-            }));
-        ON_CALL(*tracked_component_, do_get_cursor_position())
-            .WillByDefault(Invoke([this] { return tracked_cursor_position_; }));
-
-        viewport_->set_size(viewport_size);
-    }
-
-private:
-    terminalpp::point tracked_cursor_position_;
-};
+using viewport_cursor_tracking_test = 
+    viewport_mock_test_with_data<viewport_cursor_test_data>;
 
 }
 

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -158,5 +158,15 @@ INSTANTIATE_TEST_CASE_P(
             {5, 0}, {2, 0}, {2, 3}, {0, 2}, {{2, 1}, {3, 3}}
         },
 
+        // Cursor is moved to the north of the visual zone.
+        viewport_cursor_test_data{
+            {0, 5}, {0, 2}, {0, 2}, {0, 0}, {{0, 2}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 5}, {0, 2}, {0, 1}, {0, 0}, {{0, 1}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 5}, {0, 2}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
+        },
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -105,5 +105,16 @@ INSTANTIATE_TEST_CASE_P(
         viewport_cursor_test_data{
             {0, 0}, {0, 0}, {1, 1}, {1, 1}, {{0, 0}, {3, 3}}
         },
+
+        // Cursor is moved to the east of the visual zone
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {3, 0}, {2, 0}, {{1, 0}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {4, 0}, {2, 0}, {{2, 0}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {5, 0}, {2, 0}, {{3, 0}, {3, 3}}
+        },
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -1,0 +1,75 @@
+#include "viewport_test.hpp"
+#include <munin/render_surface.hpp>
+#include <munin/viewport.hpp>
+#include <terminalpp/canvas.hpp>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using testing::Return;
+using testing::ValuesIn;
+using testing::_;
+
+namespace {
+
+using viewport_cursor_test_data = std::tuple<
+    terminalpp::point,     // origin tracked cursor position
+    terminalpp::point,     // expected viewport origin cursor position
+    terminalpp::point,     // destination tracked cursor position
+    terminalpp::point,     // expected destination viewport cursor position
+    terminalpp::rectangle  // expected tracked draw area
+>;
+
+class viewport_cursor_tracking_test
+  : public a_viewport_with_mock_tracked_component,
+    public testing::TestWithParam<viewport_cursor_test_data>
+{
+protected:
+    viewport_cursor_tracking_test()
+    {
+        static auto constexpr tracked_component_preferred_size = terminalpp::extent{6, 6};
+        static auto constexpr viewport_size = terminalpp::extent{3, 3};
+
+        ON_CALL(*tracked_component_, do_get_preferred_size())
+            .WillByDefault(Return(tracked_component_preferred_size));
+        tracked_component_->on_preferred_size_changed();
+
+        viewport_->set_size(viewport_size);
+    }
+};
+
+}
+
+TEST_P(viewport_cursor_tracking_test, viewports_track_cursor_movement)
+{
+    auto const &param = GetParam();
+    auto const &origin_tracked_cursor_position = std::get<0>(param);
+    auto const &expected_viewport_cursor_position = std::get<1>(param);
+    auto const &destination_tracked_cursor_position = std::get<2>(param);
+    auto const &expected_destination_viewport_cursor_position = std::get<3>(param);
+    auto const &expected_tracked_draw_area = std::get<4>(param);
+
+    tracked_component_->set_cursor_position(origin_tracked_cursor_position);
+    ASSERT_EQ(expected_viewport_cursor_position, viewport_->get_cursor_position());
+
+    tracked_component_->set_cursor_position(destination_tracked_cursor_position);
+    ASSERT_EQ(expected_destination_viewport_cursor_position, viewport_->get_cursor_position());
+
+    EXPECT_CALL(*tracked_component_, do_draw(_, expected_tracked_draw_area));
+
+    terminalpp::canvas cvs{{5, 5}};
+    munin::render_surface surface{cvs};
+    surface.offset_by({1, 1});
+    viewport_->draw(surface, {{}, viewport_->get_size()});
+};
+
+
+INSTANTIATE_TEST_CASE_P(
+    viewport_cursor_tracking,
+    viewport_cursor_tracking_test,
+    ValuesIn({
+        // Base case: cursor is unmoved
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
+        },
+    })
+);

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -142,7 +142,7 @@ INSTANTIATE_TEST_CASE_P(
             {5, 0}, {2, 0}, {3, 2}, {0, 2}, {{3, 0}, {3, 3}}
         },
 
-        // Cursor is moved to the west of the visual zone
+        // Cursor is moved to the west of the visual zone.
         viewport_cursor_test_data{
             {5, 0}, {2, 0}, {2, 0}, {0, 0}, {{2, 0}, {3, 3}}
         },
@@ -152,5 +152,11 @@ INSTANTIATE_TEST_CASE_P(
         viewport_cursor_test_data{
             {5, 0}, {2, 0}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
         },
+
+        // Cursor is moved south-west of the visual zone.
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {2, 3}, {0, 2}, {{2, 1}, {3, 3}}
+        },
+
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -142,5 +142,15 @@ INSTANTIATE_TEST_CASE_P(
             {5, 0}, {2, 0}, {3, 2}, {0, 2}, {{3, 0}, {3, 3}}
         },
 
+        // Cursor is moved to the west of the visual zone
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {2, 0}, {0, 0}, {{2, 0}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {1, 0}, {0, 0}, {{1, 0}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
+        },
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -133,5 +133,14 @@ INSTANTIATE_TEST_CASE_P(
             {0, 0}, {0, 0}, {3, 3}, {2, 2}, {{1, 1}, {3, 3}}
         },
 
+        // Cursor is moved inside the visual zone after the
+        // visual zone is moved.
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {4, 1}, {1, 1}, {{3, 0}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {5, 0}, {2, 0}, {3, 2}, {0, 2}, {{3, 0}, {3, 3}}
+        },
+
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+using testing::Invoke;
 using testing::Return;
 using testing::ValuesIn;
 using testing::_;
@@ -29,12 +30,27 @@ protected:
         static auto constexpr tracked_component_preferred_size = terminalpp::extent{6, 6};
         static auto constexpr viewport_size = terminalpp::extent{3, 3};
 
+        // Set the preferred size of the tracked component.  It is tested elsewhere that
+        // a viewport allows the tracked component its preferred size.
         ON_CALL(*tracked_component_, do_get_preferred_size())
             .WillByDefault(Return(tracked_component_preferred_size));
         tracked_component_->on_preferred_size_changed();
 
+        // Mock the cursor position of the tracked component so that it does what it
+        // is told and announces it to the viewport.
+        ON_CALL(*tracked_component_, do_set_cursor_position(_))
+            .WillByDefault(Invoke([this](auto const &pos) { 
+                tracked_cursor_position_ = pos;
+                tracked_component_->on_cursor_position_changed();
+            }));
+        ON_CALL(*tracked_component_, do_get_cursor_position())
+            .WillByDefault(Invoke([this] { return tracked_cursor_position_; }));
+
         viewport_->set_size(viewport_size);
     }
+
+private:
+    terminalpp::point tracked_cursor_position_;
 };
 
 }
@@ -48,12 +64,25 @@ TEST_P(viewport_cursor_tracking_test, viewports_track_cursor_movement)
     auto const &expected_destination_viewport_cursor_position = std::get<3>(param);
     auto const &expected_tracked_draw_area = std::get<4>(param);
 
+    // Set the origin cursor position.
     tracked_component_->set_cursor_position(origin_tracked_cursor_position);
     ASSERT_EQ(expected_viewport_cursor_position, viewport_->get_cursor_position());
 
+    // Some (and only some) cursor movements require the real cursor position to
+    // change.  Record whether it does, and assert whether it should.
+    bool cursor_position_changed = false;
+    viewport_->on_cursor_position_changed.connect(
+        [&cursor_position_changed] { cursor_position_changed = true; }
+    );
+    
     tracked_component_->set_cursor_position(destination_tracked_cursor_position);
     ASSERT_EQ(expected_destination_viewport_cursor_position, viewport_->get_cursor_position());
 
+    auto const cursor_position_expected_to_change = 
+        expected_viewport_cursor_position != expected_destination_viewport_cursor_position;
+    ASSERT_EQ(cursor_position_expected_to_change, cursor_position_changed);
+
+    // Draw the viewport and check that the correct part of the tracked area is drawn.
     EXPECT_CALL(*tracked_component_, do_draw(_, expected_tracked_draw_area));
 
     terminalpp::canvas cvs{{5, 5}};
@@ -70,6 +99,11 @@ INSTANTIATE_TEST_CASE_P(
         // Base case: cursor is unmoved
         viewport_cursor_test_data{
             {0, 0}, {0, 0}, {0, 0}, {0, 0}, {{0, 0}, {3, 3}}
+        },
+
+        // Cursor is moved within visual zone
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {1, 1}, {1, 1}, {{0, 0}, {3, 3}}
         },
     })
 );

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -116,5 +116,22 @@ INSTANTIATE_TEST_CASE_P(
         viewport_cursor_test_data{
             {0, 0}, {0, 0}, {5, 0}, {2, 0}, {{3, 0}, {3, 3}}
         },
+
+        // Cursor is moved to the south of the visual zone
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {0, 3}, {0, 2}, {{0, 1}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {0, 4}, {0, 2}, {{0, 2}, {3, 3}}
+        },
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {0, 5}, {0, 2}, {{0, 3}, {3, 3}}
+        },
+    
+        // Cursor is moved south-east of the visual zone.
+        viewport_cursor_test_data{
+            {0, 0}, {0, 0}, {3, 3}, {2, 2}, {{1, 1}, {3, 3}}
+        },
+
     })
 );

--- a/test/src/viewport/viewport_redraw_test.cpp
+++ b/test/src/viewport/viewport_redraw_test.cpp
@@ -1,0 +1,65 @@
+#include "viewport_test.hpp"
+#include <tuple>
+
+using testing::ValuesIn;
+
+namespace {
+
+using cursor_movement_redraw_test_data = std::tuple<
+    std::initializer_list<terminalpp::point>, // initial cursor movements
+    terminalpp::point,                        // cursor movement whose redraw 
+                                              // we want to track
+    boost::optional<terminalpp::rectangle>    // expected redraw region
+>;
+
+class viewport_cursor_movement_redraw_test
+  : public viewport_mock_test_with_data<cursor_movement_redraw_test_data>
+{
+};
+
+}
+
+TEST_P(viewport_cursor_movement_redraw_test, cursor_movements)
+{
+    using std::get;
+
+    auto const &param = GetParam();
+    auto const &initial_cursor_movements = get<0>(param);
+    auto const &cursor_movement = get<1>(param);
+    auto const &expected_redraw_region = get<2>(param);
+
+    // Make a series of initial cursor movements to set up the desired state.
+    for (auto const &position : initial_cursor_movements)
+    {
+        tracked_component_->set_cursor_position(position);
+    }
+
+    // Subscribe to the viewport's redraw event so that we can catch whether
+    // a redraw occurred.
+    boost::optional<terminalpp::rectangle> redraw_region;
+    viewport_->on_redraw.connect(
+        [&](std::vector<terminalpp::rectangle> const &regions)
+        {
+            ASSERT_EQ(1u, regions.size());
+            redraw_region = regions[0];
+        });
+
+    // Fire off the cursor movement whose behaviour we are verifying
+    tracked_component_->set_cursor_position(cursor_movement);
+
+    // Make the behavioural assertions.
+    ASSERT_EQ(expected_redraw_region, redraw_region);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    moving_cursors_redraw_viewports,
+    viewport_cursor_movement_redraw_test,
+    ValuesIn({
+        // Default case: moving the cursor to its existing position
+        // doesn't redraw the viewport.
+        cursor_movement_redraw_test_data{
+            {}, {}, {}
+        },
+    })
+);
+

--- a/test/src/viewport/viewport_redraw_test.cpp
+++ b/test/src/viewport/viewport_redraw_test.cpp
@@ -60,6 +60,37 @@ INSTANTIATE_TEST_CASE_P(
         cursor_movement_redraw_test_data{
             {}, {}, {}
         },
+        
+        // Moving the cursor within the viewed area will not prompt a redraw.
+        cursor_movement_redraw_test_data{
+            {}, {0, 2}, {}
+        },        
+
+        cursor_movement_redraw_test_data{
+            {}, {2, 0}, {}
+        },        
+
+        cursor_movement_redraw_test_data{
+            {}, {2, 2}, {}
+        },        
+        
+        // Moving the cursor just beyond the viewed area will shift the
+        // viewport, and prompt a redraw of the entire viewed area.
+        cursor_movement_redraw_test_data{
+            {}, {3, 0}, terminalpp::rectangle{{0, 0}, {3, 3}}
+        },        
+        
+        cursor_movement_redraw_test_data{
+            {}, {0, 3}, terminalpp::rectangle{{0, 0}, {3, 3}}
+        },        
+
+        cursor_movement_redraw_test_data{
+            {{0, 3}}, {0, 0}, terminalpp::rectangle{{0, 0}, {3, 3}}
+        },        
+
+        cursor_movement_redraw_test_data{
+            {{3, 0}}, {0, 0}, terminalpp::rectangle{{0, 0}, {3, 3}}
+        },        
     })
 );
 

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -42,16 +42,16 @@ TEST_P(viewport_size_test, viewports_track_size_changes)
     tracked_component_->on_preferred_size_changed();
     tracked_component_->set_cursor_position(tracked_component_cursor_position);
     
-    // Change the size of the viewport.  This may cause the viewport to resize
-    // and reposition the tracked component.
-    viewport_->set_size(changed_viewport_size);
-
     // Perform any extra cursor movements to set the viewport up.
     for (auto const &cursor_position : extra_tracked_cursor_movements)
     {
         tracked_component_->set_cursor_position(cursor_position);
     }
     
+    // Change the size of the viewport.  This may cause the viewport to resize
+    // and reposition the tracked component.
+    viewport_->set_size(changed_viewport_size);
+
     // This may have changed the viewport's idea of where the cursor is.
     ASSERT_EQ(expected_viewport_cursor_position, viewport_->get_cursor_position());
     
@@ -97,13 +97,24 @@ INSTANTIATE_TEST_CASE_P(
         viewport_size_test_data{
             {6, 6}, {5, 0}, {2, 3}, {{4, 0}}, {1, 0}, {{3, 0}, {2, 3}}
         },
+
+        // Similarly for scrolling off the bottom and back.
+        viewport_size_test_data{
+            {6, 6}, {0, 5}, {3, 2}, {{0, 4}}, {0, 1}, {{0, 3}, {3, 2}}
+        },
         
         // However, if the viewport has been scrolled to the right, and 
         // shrinking the viewport would move the cursor out of sight, then
         // the viewport will instead draw from a position that contains the
         // cursor.
         viewport_size_test_data{
-            {6, 6}, {5, 0}, {2, 3}, {}, {2, 0}, {{4, 0}, {2, 3}}
+            {6, 6}, {5, 0}, {2, 3}, {}, {1, 0}, {{4, 0}, {2, 3}}
+        },
+
+        // Similarly for scrolling off the bottom and then resizing so that
+        // the cursor is no longer visible.
+        viewport_size_test_data{
+            {6, 6}, {0, 5}, {3, 2}, {}, {0, 1}, {{0, 4}, {3, 2}}
         },
     })
 );

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -1,0 +1,60 @@
+#include "viewport_test.hpp"
+#include <munin/viewport.hpp>
+#include <gtest/gtest.h>
+
+using testing::ValuesIn;
+
+namespace {
+    
+using viewport_size_test_data = std::tuple<
+    terminalpp::extent, // component's preferred size
+    terminalpp::point,  // initial tracked component cursor position
+    terminalpp::extent, // changed viewport size
+    terminalpp::point   // expected viewport cursor position
+>;
+
+using viewport_size_test = 
+    viewport_mock_test_with_data<viewport_size_test_data>;
+
+}
+
+TEST_P(viewport_size_test, viewports_track_size_changes)
+{
+    using std::get;
+    using testing::Return;
+    
+    auto const &param = GetParam();
+    auto const &tracked_component_preferred_size = get<0>(param);
+    auto const &tracked_component_cursor_position = get<1>(param);
+    auto const &changed_viewport_size = get<2>(param);
+    auto const &expected_viewport_cursor_position = get<3>(param);
+    
+    // Set up the conditions of the tracked component
+    ON_CALL(*tracked_component_, do_get_preferred_size())
+        .WillByDefault(Return(tracked_component_preferred_size));
+    tracked_component_->on_preferred_size_changed();
+    tracked_component_->set_cursor_position(tracked_component_cursor_position);
+    
+    // Change the size of the viewport.  This may cause the viewport's
+    // cursor position to change, though the tracked component's cursor
+    // position must not.
+    auto const old_tracked_cursor_position = 
+        tracked_component_->get_cursor_position();
+    viewport_->set_size(changed_viewport_size);
+    auto const new_tracked_cursor_position =
+        tracked_component_->get_cursor_position();
+        
+    ASSERT_EQ(old_tracked_cursor_position, new_tracked_cursor_position);
+    ASSERT_EQ(expected_viewport_cursor_position, viewport_->get_cursor_position());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    changing_viewport_size,
+    viewport_size_test,
+    ValuesIn({
+        // Base case: everything stays the same.
+        viewport_size_test_data{
+            {6, 6}, {0, 0}, {6, 6}, {0, 0}
+        },
+    })
+);

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -1,16 +1,20 @@
 #include "viewport_test.hpp"
+#include <munin/render_surface.hpp>
 #include <munin/viewport.hpp>
+#include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
 using testing::ValuesIn;
+using testing::_;
 
 namespace {
     
 using viewport_size_test_data = std::tuple<
-    terminalpp::extent, // component's preferred size
-    terminalpp::point,  // initial tracked component cursor position
-    terminalpp::extent, // changed viewport size
-    terminalpp::point   // expected viewport cursor position
+    terminalpp::extent,    // component's preferred size
+    terminalpp::point,     // initial tracked component cursor position
+    terminalpp::extent,    // changed viewport size
+    terminalpp::point,     // expected viewport cursor position
+    terminalpp::rectangle  // expected tracked draw area
 >;
 
 using viewport_size_test = 
@@ -28,6 +32,7 @@ TEST_P(viewport_size_test, viewports_track_size_changes)
     auto const &tracked_component_cursor_position = get<1>(param);
     auto const &changed_viewport_size = get<2>(param);
     auto const &expected_viewport_cursor_position = get<3>(param);
+    auto const &expected_tracked_draw_area = get<4>(param);
     
     // Set up the conditions of the tracked component
     ON_CALL(*tracked_component_, do_get_preferred_size())
@@ -35,17 +40,20 @@ TEST_P(viewport_size_test, viewports_track_size_changes)
     tracked_component_->on_preferred_size_changed();
     tracked_component_->set_cursor_position(tracked_component_cursor_position);
     
-    // Change the size of the viewport.  This may cause the viewport's
-    // cursor position to change, though the tracked component's cursor
-    // position must not.
-    auto const old_tracked_cursor_position = 
-        tracked_component_->get_cursor_position();
+    // Change the size of the viewport.  This may cause the viewport to resize
+    // and reposition the tracked component.
     viewport_->set_size(changed_viewport_size);
-    auto const new_tracked_cursor_position =
-        tracked_component_->get_cursor_position();
-        
-    ASSERT_EQ(old_tracked_cursor_position, new_tracked_cursor_position);
+
+    // This may have changed the viewport's idea of where the cursor is.
     ASSERT_EQ(expected_viewport_cursor_position, viewport_->get_cursor_position());
+    
+    // Draw the viewport and check that the correct part of the tracked area is drawn.
+    EXPECT_CALL(*tracked_component_, do_draw(_, expected_tracked_draw_area));
+
+    terminalpp::canvas cvs{{5, 5}};
+    munin::render_surface surface{cvs};
+    surface.offset_by({1, 1});
+    viewport_->draw(surface, {{}, viewport_->get_size()});
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -54,26 +62,26 @@ INSTANTIATE_TEST_CASE_P(
     ValuesIn({
         // Base case: everything stays the same.
         viewport_size_test_data{
-            {6, 6}, {1, 1}, {3, 3}, {1, 1}
+            {6, 6}, {1, 1}, {3, 3}, {1, 1}, {{0, 0}, {3, 3}}
         },
         
         // Extending the viewport eastward when at the origin does not
-        // move the cursor.
+        // move the cursor, but does expand the draw area.
         viewport_size_test_data{
-            {6, 6}, {1, 1}, {6, 3}, {1, 1}
+            {6, 6}, {1, 1}, {6, 3}, {1, 1}, {{0, 0}, {6, 3}}
         },
         
+
         // Extending the viewport southward when at the origin does not
-        // move the cursor.
+        // move the cursor, but does expand the draw area.
         viewport_size_test_data{
-            {6, 6}, {1, 1}, {3, 6}, {1, 1}
+            {6, 6}, {1, 1}, {3, 6}, {1, 1}, {{0, 0}, {3, 6}}
         },
         
         // Shrinking the viewport so that the cursor is still in view does
-        // not move the cursor.
+        // not move the cursor, but does shrink the draw area.
         viewport_size_test_data{
-            {6, 6}, {1, 1}, {2, 2}, {1, 1}
+            {6, 6}, {1, 1}, {2, 2}, {1, 1}, {{0, 0}, {2, 2}}
         },
-        
     })
 );

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -54,7 +54,26 @@ INSTANTIATE_TEST_CASE_P(
     ValuesIn({
         // Base case: everything stays the same.
         viewport_size_test_data{
-            {6, 6}, {0, 0}, {6, 6}, {0, 0}
+            {6, 6}, {1, 1}, {3, 3}, {1, 1}
         },
+        
+        // Extending the viewport eastward when at the origin does not
+        // move the cursor.
+        viewport_size_test_data{
+            {6, 6}, {1, 1}, {6, 3}, {1, 1}
+        },
+        
+        // Extending the viewport southward when at the origin does not
+        // move the cursor.
+        viewport_size_test_data{
+            {6, 6}, {1, 1}, {3, 6}, {1, 1}
+        },
+        
+        // Shrinking the viewport so that the cursor is still in view does
+        // not move the cursor.
+        viewport_size_test_data{
+            {6, 6}, {1, 1}, {2, 2}, {1, 1}
+        },
+        
     })
 );

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -1,7 +1,16 @@
+#include "fill_canvas.hpp"
+#include "mock/component.hpp"
 #include <munin/edit.hpp>
+#include <munin/render_surface.hpp>
 #include <munin/viewport.hpp>
+#include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
+using testing::Return;
+using testing::Values;
+
+namespace {
+    
 class a_new_viewport : public testing::Test
 {
 protected:
@@ -9,7 +18,76 @@ protected:
     std::shared_ptr<munin::viewport> viewport_{munin::make_viewport(edit_)};
 };
 
+}
+
 TEST_F(a_new_viewport, is_a_component)
 {
     std::shared_ptr<munin::component> comp = viewport_;
 }
+
+TEST_F(a_new_viewport, of_zero_size_draws_nothing)
+{
+    terminalpp::canvas cvs{{4, 3}};
+    fill_canvas(cvs, 'x');
+    
+    viewport_->set_position({1, 1});
+    viewport_->set_size({0, 0});
+    
+    munin::render_surface surface{cvs};
+    surface.offset_by({1, 1});
+    viewport_->draw(surface, {{}, viewport_->get_size()});
+    
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[0][0]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[1][0]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[2][0]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[3][0]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[0][1]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[1][1]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[2][1]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[3][1]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[0][2]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[1][2]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[2][2]);
+    ASSERT_EQ(terminalpp::element{'x'}, cvs[3][2]);
+}
+
+namespace {
+
+class viewport_preferred_size_test 
+  : public testing::TestWithParam<terminalpp::extent>
+{
+protected:
+    std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
+    std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
+};
+
+}
+
+TEST_P(viewport_preferred_size_test, the_preferred_size_of_a_viewport_is_the_same_as_the_preferred_size_of_the_tracked_component)
+{
+    auto const preferred_size = GetParam();
+    
+    bool preferred_size_changed = false;
+    viewport_->on_preferred_size_changed.connect(
+        [&]() { preferred_size_changed = true; });
+        
+    ON_CALL(*tracked_component_, do_get_preferred_size())
+        .WillByDefault(Return(preferred_size));
+        
+    tracked_component_->on_preferred_size_changed();
+    
+    ASSERT_EQ(preferred_size, viewport_->get_preferred_size());
+    ASSERT_TRUE(preferred_size_changed);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    viewport_size,
+    viewport_preferred_size_test,
+    Values
+    (
+        terminalpp::extent(0, 0),
+        terminalpp::extent(1, 1),
+        terminalpp::extent(4, 5)
+    )
+);
+

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -6,8 +6,10 @@
 #include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
+using testing::Invoke;
 using testing::Return;
 using testing::Values;
+using testing::_;
 
 namespace {
     
@@ -132,3 +134,21 @@ TEST_F(a_viewport, allows_the_tracked_component_its_preferred_size)
     tracked_component_->on_preferred_size_changed();
 }
 
+TEST_F(a_viewport, forwards_events_to_the_tracked_component)
+{
+    char const *test_event = "test event";
+    boost::any received_event;
+    
+    EXPECT_CALL(*tracked_component_, do_event(_))
+        .WillOnce(Invoke([&received_event](const boost::any& event)
+        {
+            received_event = event;
+        }));
+
+    viewport_->event(test_event);
+    
+    char const **result = boost::any_cast<char const*>(&received_event);
+    ASSERT_TRUE(result != nullptr);
+    ASSERT_TRUE(*result != nullptr);
+    ASSERT_STREQ(test_event, *result);
+}

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -1,0 +1,15 @@
+#include <munin/edit.hpp>
+#include <munin/viewport.hpp>
+#include <gtest/gtest.h>
+
+class a_new_viewport : public testing::Test
+{
+protected:
+    std::shared_ptr<munin::edit> edit_{munin::make_edit()};
+    std::shared_ptr<munin::viewport> viewport_{munin::make_viewport(edit_)};
+};
+
+TEST_F(a_new_viewport, is_a_component)
+{
+    std::shared_ptr<munin::component> comp = viewport_;
+}

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -53,12 +53,17 @@ TEST_F(a_new_viewport, of_zero_size_draws_nothing)
 
 namespace {
 
-class viewport_preferred_size_test 
-  : public testing::TestWithParam<terminalpp::extent>
+class a_viewport_with_mock_tracked_component
 {
 protected:
     std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
     std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
+};
+
+class viewport_preferred_size_test 
+  : public a_viewport_with_mock_tracked_component,
+    public testing::TestWithParam<terminalpp::extent>
+{
 };
 
 }
@@ -90,4 +95,40 @@ INSTANTIATE_TEST_CASE_P(
         terminalpp::extent(4, 5)
     )
 );
+
+namespace 
+{
+
+class a_viewport : 
+    public a_viewport_with_mock_tracked_component,
+    public testing::Test
+{
+};
+
+}
+
+TEST_F(a_viewport, allows_the_tracked_component_its_preferred_size)
+{
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{3, 3};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
+    }
+    
+    tracked_component_->on_preferred_size_changed();
+
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{17, 4};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
+    }
+
+    tracked_component_->on_preferred_size_changed();
+}
 

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -1,10 +1,11 @@
+#include "viewport_test.hpp"
 #include "fill_canvas.hpp"
-#include "mock/component.hpp"
 #include <munin/edit.hpp>
 #include <munin/render_surface.hpp>
 #include <munin/viewport.hpp>
 #include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 using testing::Invoke;
 using testing::Return;
@@ -54,13 +55,6 @@ TEST_F(a_new_viewport, of_zero_size_draws_nothing)
 }
 
 namespace {
-
-class a_viewport_with_mock_tracked_component
-{
-protected:
-    std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
-    std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
-};
 
 class viewport_preferred_size_test 
   : public a_viewport_with_mock_tracked_component,

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -109,8 +109,37 @@ class a_viewport :
 
 }
 
-TEST_F(a_viewport, allows_the_tracked_component_its_preferred_size)
+TEST_F(a_viewport, with_a_size_larger_than_the_preferred_size_of_the_tracked_component_sets_the_tracked_component_to_the_larger_size)
 {
+    auto const viewport_size = terminalpp::extent{5, 5};
+    viewport_->set_size(viewport_size);
+    
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{3, 3};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(viewport_size));
+        tracked_component_->on_preferred_size_changed();
+    }
+    
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{2, 3};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(viewport_size));
+        tracked_component_->on_preferred_size_changed();
+    }
+}
+
+TEST_F(a_viewport, with_a_size_smaller_than_the_tracked_component_allows_the_tracked_component_its_preferred_size)
+{
+    auto const viewport_size = terminalpp::extent{2, 2};
+    viewport_->set_size(viewport_size);
+    
     {
         testing::InSequence _;
         
@@ -118,9 +147,9 @@ TEST_F(a_viewport, allows_the_tracked_component_its_preferred_size)
         EXPECT_CALL(*tracked_component_, do_get_preferred_size)
             .WillOnce(Return(preferred_size));
         EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
+
+        tracked_component_->on_preferred_size_changed();
     }
-    
-    tracked_component_->on_preferred_size_changed();
 
     {
         testing::InSequence _;
@@ -129,9 +158,9 @@ TEST_F(a_viewport, allows_the_tracked_component_its_preferred_size)
         EXPECT_CALL(*tracked_component_, do_get_preferred_size)
             .WillOnce(Return(preferred_size));
         EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
-    }
 
-    tracked_component_->on_preferred_size_changed();
+        tracked_component_->on_preferred_size_changed();
+    }
 }
 
 TEST_F(a_viewport, forwards_events_to_the_tracked_component)

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -133,6 +133,17 @@ TEST_F(a_viewport, with_a_size_larger_than_the_preferred_size_of_the_tracked_com
         EXPECT_CALL(*tracked_component_, do_set_size(viewport_size));
         tracked_component_->on_preferred_size_changed();
     }
+
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{3, 3};
+        auto const new_viewport_size = terminalpp::extent{7, 7};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(new_viewport_size));
+        viewport_->set_size(new_viewport_size);
+    }
 }
 
 TEST_F(a_viewport, with_a_size_smaller_than_the_tracked_component_allows_the_tracked_component_its_preferred_size)
@@ -160,6 +171,17 @@ TEST_F(a_viewport, with_a_size_smaller_than_the_tracked_component_allows_the_tra
         EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
 
         tracked_component_->on_preferred_size_changed();
+    }
+
+    {
+        testing::InSequence _;
+        
+        auto const preferred_size = terminalpp::extent{17, 4};
+        auto const new_viewport_size = terminalpp::extent{3, 3};
+        EXPECT_CALL(*tracked_component_, do_get_preferred_size)
+            .WillOnce(Return(preferred_size));
+        EXPECT_CALL(*tracked_component_, do_set_size(preferred_size));
+        viewport_->set_size(new_viewport_size);
     }
 }
 

--- a/test/src/viewport/viewport_test.hpp
+++ b/test/src/viewport/viewport_test.hpp
@@ -1,0 +1,9 @@
+#include "mock/component.hpp"
+#include <munin/viewport.hpp>
+
+class a_viewport_with_mock_tracked_component
+{
+protected:
+    std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
+    std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
+};

--- a/test/src/viewport/viewport_test.hpp
+++ b/test/src/viewport/viewport_test.hpp
@@ -7,3 +7,41 @@ protected:
     std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
     std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
 };
+
+template <typename TestData>
+class viewport_mock_test_with_data
+  : public a_viewport_with_mock_tracked_component,
+    public testing::TestWithParam<TestData>
+{
+protected:
+    viewport_mock_test_with_data()
+    {
+        using testing::Invoke;
+        using testing::Return;
+        using testing::_;
+        
+        static auto constexpr tracked_component_preferred_size = terminalpp::extent{6, 6};
+        static auto constexpr viewport_size = terminalpp::extent{3, 3};
+
+        // Set the preferred size of the tracked component.  It is tested elsewhere that
+        // a viewport allows the tracked component its preferred size.
+        ON_CALL(*tracked_component_, do_get_preferred_size())
+            .WillByDefault(Return(tracked_component_preferred_size));
+        tracked_component_->on_preferred_size_changed();
+
+        // Mock the cursor position of the tracked component so that it does what it
+        // is told and announces it to the viewport.
+        ON_CALL(*tracked_component_, do_set_cursor_position(_))
+            .WillByDefault(Invoke([this](auto const &pos) { 
+                tracked_cursor_position_ = pos;
+                tracked_component_->on_cursor_position_changed();
+            }));
+        ON_CALL(*tracked_component_, do_get_cursor_position())
+            .WillByDefault(Invoke([this] { return tracked_cursor_position_; }));
+
+        viewport_->set_size(viewport_size);
+    }
+
+private:
+    terminalpp::point tracked_cursor_position_;
+};


### PR DESCRIPTION
Implements a viewport that can be used to provide a smaller window into a larger component, and tracks where it should be looking by cursor position.

Closes #54.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/154)
<!-- Reviewable:end -->
