### PR TITLE
Removed withTests option from Conan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,12 +106,10 @@ before_script:
   - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite || true
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
   - conan remote add kazdragon-conan https://api.bintray.com/conan/kazdragon/conan-public || true
-  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o munin:withTests=True -o munin:shared=$SHARED --build=missing
-  - conan build -c ..
-  - $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DMUNIN_SANITIZE=$SANITIZE -DMUNIN_COVERAGE=$COVERAGE ..
+  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o munin:shared=$SHARED --build=missing
 
 script:
-  - make -j2
+  - conan build ..
   - if [ "$COVERAGE" == "ON" ]; then
         $LCOV --gcov-tool=gcov-5 --base-directory . --directory . --zerocounters -q;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(MUNIN_WITH_TESTS "Build with tests included" False)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
 
@@ -123,99 +121,97 @@ target_link_libraries(munin
         CONAN_PKG::boost_signals2
 )
 
-if (MUNIN_WITH_TESTS)
-    enable_testing()
+enable_testing()
 
-    add_executable(munin_tester test/src/redraw.cpp)
-    
-    target_sources(munin_tester
-        PRIVATE
-            test/src/container/container_test.hpp
-            test/src/window/window_test.hpp
-            test/include/fill_canvas.hpp
-            test/include/redraw.hpp
-            test/include/mock/component.hpp
-            test/include/mock/layout.hpp
-            test/src/fill_canvas.cpp
-            test/src/redraw.cpp
-            test/src/mock/component.cpp
-            test/src/mock/frame.cpp
-            test/src/algorithm/algorithm_test.cpp
-            test/src/aligned_layout/aligned_layout_test.cpp
-            test/src/basic_component/new_basic_component_test.cpp
-            test/src/basic_component/unfocused_basic_component_test.cpp
-            test/src/basic_component/focused_basic_component_test.cpp
-            test/src/basic_component/basic_component_test.cpp
-            test/src/brush/brush_test.cpp
-            test/src/brush/brush_json_test.cpp
-            test/src/brush/brush_redraw_test.cpp
-            test/src/brush/new_brush_test.cpp
-            test/src/button/button_test.cpp
-            test/src/button/button_json_test.cpp
-            test/src/compass_layout/compass_layout_test.cpp
-            test/src/container/container_test.cpp
-            test/src/container/container_cursor_test.cpp
-            test/src/container/container_draw_test.cpp
-            test/src/container/container_event_test.cpp
-            test/src/container/container_focus_test.cpp
-            test/src/container/container_focus_next_test.cpp
-            test/src/container/container_focus_previous_test.cpp
-            test/src/container/container_json_test.cpp
-            test/src/container/container_redraw_test.cpp
-            test/src/container/container_subcomponent_focus_test.cpp
-            test/src/container/container_layout_test.cpp
-            test/src/edit/edit_test.cpp
-            test/src/edit/edit_mouse_test.cpp
-            test/src/edit/edit_with_content_test.cpp
-            test/src/filled_box/new_filled_box_test.cpp
-            test/src/filled_box/filled_box_test.cpp
-            test/src/filled_box/functional_filled_box_test.cpp
-            test/src/framed_component/framed_component_focus_test.cpp
-            test/src/framed_component/framed_component_json_test.cpp
-            test/src/framed_component/framed_component_test.cpp
-            test/src/framed_component/framed_component_mouse_test.cpp
-            test/src/grid_layout/grid_layout_test.cpp
-            test/src/horizontal_strip_layout/horizontal_strip_layout_test.cpp
-            test/src/image/image_json_test.cpp
-            test/src/image/image_test.cpp
-            test/src/image/image_redraw_test.cpp
-            test/src/image/new_image_test.cpp
-            test/src/null_layout/null_layout_test.cpp
-            test/src/render_surface/render_surface_capabilities_test.cpp
-            test/src/render_surface/render_surface_test.cpp
-            test/src/solid_frame/solid_frame_json_test.cpp
-            test/src/solid_frame/solid_frame_test.cpp
-            test/src/text_area/new_text_area_test.cpp
-            test/src/text_area/text_area_test.cpp
-            test/src/text_area/text_area_with_text_inserted_test.cpp
-            test/src/text_area/text_area_test.hpp
-            test/src/titled_frame/titled_frame_json_test.cpp
-            test/src/titled_frame/titled_frame_test.cpp
-            test/src/toggle_button/toggle_button_test.cpp
-            test/src/toggle_button/toggle_button_json_test.cpp
-            test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
-            test/src/viewport/viewport_test.hpp
-            test/src/viewport/viewport_test.cpp
-            test/src/viewport/viewport_cursor_test.cpp
-            test/src/viewport/viewport_redraw_test.cpp
-            test/src/viewport/viewport_size_test.cpp
-            test/src/window/window_json_test.cpp
-            test/src/window/window_test.cpp
-            test/src/window/window_repaint_test.cpp
-    ) 
+add_executable(munin_tester test/src/redraw.cpp)
 
-    target_include_directories(munin_tester
-        PRIVATE
-            ${PROJECT_SOURCE_DIR}/test/include
-    )
+target_sources(munin_tester
+    PRIVATE
+        test/src/container/container_test.hpp
+        test/src/window/window_test.hpp
+        test/include/fill_canvas.hpp
+        test/include/redraw.hpp
+        test/include/mock/component.hpp
+        test/include/mock/layout.hpp
+        test/src/fill_canvas.cpp
+        test/src/redraw.cpp
+        test/src/mock/component.cpp
+        test/src/mock/frame.cpp
+        test/src/algorithm/algorithm_test.cpp
+        test/src/aligned_layout/aligned_layout_test.cpp
+        test/src/basic_component/new_basic_component_test.cpp
+        test/src/basic_component/unfocused_basic_component_test.cpp
+        test/src/basic_component/focused_basic_component_test.cpp
+        test/src/basic_component/basic_component_test.cpp
+        test/src/brush/brush_test.cpp
+        test/src/brush/brush_json_test.cpp
+        test/src/brush/brush_redraw_test.cpp
+        test/src/brush/new_brush_test.cpp
+        test/src/button/button_test.cpp
+        test/src/button/button_json_test.cpp
+        test/src/compass_layout/compass_layout_test.cpp
+        test/src/container/container_test.cpp
+        test/src/container/container_cursor_test.cpp
+        test/src/container/container_draw_test.cpp
+        test/src/container/container_event_test.cpp
+        test/src/container/container_focus_test.cpp
+        test/src/container/container_focus_next_test.cpp
+        test/src/container/container_focus_previous_test.cpp
+        test/src/container/container_json_test.cpp
+        test/src/container/container_redraw_test.cpp
+        test/src/container/container_subcomponent_focus_test.cpp
+        test/src/container/container_layout_test.cpp
+        test/src/edit/edit_test.cpp
+        test/src/edit/edit_mouse_test.cpp
+        test/src/edit/edit_with_content_test.cpp
+        test/src/filled_box/new_filled_box_test.cpp
+        test/src/filled_box/filled_box_test.cpp
+        test/src/filled_box/functional_filled_box_test.cpp
+        test/src/framed_component/framed_component_focus_test.cpp
+        test/src/framed_component/framed_component_json_test.cpp
+        test/src/framed_component/framed_component_test.cpp
+        test/src/framed_component/framed_component_mouse_test.cpp
+        test/src/grid_layout/grid_layout_test.cpp
+        test/src/horizontal_strip_layout/horizontal_strip_layout_test.cpp
+        test/src/image/image_json_test.cpp
+        test/src/image/image_test.cpp
+        test/src/image/image_redraw_test.cpp
+        test/src/image/new_image_test.cpp
+        test/src/null_layout/null_layout_test.cpp
+        test/src/render_surface/render_surface_capabilities_test.cpp
+        test/src/render_surface/render_surface_test.cpp
+        test/src/solid_frame/solid_frame_json_test.cpp
+        test/src/solid_frame/solid_frame_test.cpp
+        test/src/text_area/new_text_area_test.cpp
+        test/src/text_area/text_area_test.cpp
+        test/src/text_area/text_area_with_text_inserted_test.cpp
+        test/src/text_area/text_area_test.hpp
+        test/src/titled_frame/titled_frame_json_test.cpp
+        test/src/titled_frame/titled_frame_test.cpp
+        test/src/toggle_button/toggle_button_test.cpp
+        test/src/toggle_button/toggle_button_json_test.cpp
+        test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
+        test/src/viewport/viewport_test.hpp
+        test/src/viewport/viewport_test.cpp
+        test/src/viewport/viewport_cursor_test.cpp
+        test/src/viewport/viewport_redraw_test.cpp
+        test/src/viewport/viewport_size_test.cpp
+        test/src/window/window_json_test.cpp
+        test/src/window/window_test.cpp
+        test/src/window/window_repaint_test.cpp
+) 
 
-    target_link_libraries(munin_tester
-        munin
-        CONAN_PKG::gtest
-    )
+target_include_directories(munin_tester
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/test/include
+)
 
-    add_test(munin_test munin_tester)
-endif()
+target_link_libraries(munin_tester
+    munin
+    CONAN_PKG::gtest
+)
+
+add_test(munin_test munin_tester)
 
 if (DOXYGEN_FOUND)
     configure_file(

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,8 +10,8 @@ class MuninConan(ConanFile):
     description = "A text-based gui component library build on Terminal++"
     topics = ("ansi-escape-codes", "text-ui")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "withTests": [True, False]}
-    default_options = {"shared": False, "withTests": False}
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     requires = ("terminalpp/1.3.3@kazdragon/conan-public",
                 "jsonformoderncpp/[>=3.3.0]@vthiery/stable",
@@ -19,12 +19,9 @@ class MuninConan(ConanFile):
                 "boost_optional/[>=1.69]@bincrafters/stable",
                 "boost_scope_exit/[>=1.69]@bincrafters/stable",
                 "boost_signals2/[>=1.69]@bincrafters/stable")
+    build_requires = ("gtest/[>=1.8.1]@bincrafters/stable")
     generators = "cmake"
 
-    def requirements(self):
-        if (self.options.withTests):
-            self.requires("gtest/[>=1.8.1]@bincrafters/stable")
-            
     def imports(self):
         # If Munin is built as shared, then running the tests will
         # rely on the shared object for terminalpp being available
@@ -37,7 +34,6 @@ class MuninConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
-        cmake.definitions["MUNIN_WITH_TESTS"] = self.options.withTests
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
gtest is now included in build_requires so that Munin is always built with
tests that can be executed, but these are not required by a downstream consumer
of the library executables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/155)
<!-- Reviewable:end -->
