### PR TITLE
Updated repo for nonstd-lite in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
 before_script:
   - mkdir build || true
   - cd build
-  - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite || true
+  - conan remote add nonstd-lite https://api.bintray.com/conan/martinmoene/nonstd-lite || true
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
   - conan remote add kazdragon-conan https://api.bintray.com/conan/kazdragon/conan-public || true
   - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o munin:shared=$SHARED --build=missing


### PR DESCRIPTION
Previously, Travis was pulling from an out-of-date, unmaintained
repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/156)
<!-- Reviewable:end -->
