### PR TITLE
Focus fixes#158

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -7,6 +7,8 @@
 #include <terminalpp/ansi/mouse.hpp>
 #include <terminalpp/rectangle.hpp>
 #include <boost/optional.hpp>
+#include <boost/range/algorithm/find_if.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/scope_exit.hpp>
 #include <vector>
 
@@ -17,56 +19,32 @@ namespace {
 using component_connections =
     std::vector<boost::signals2::connection>;
 
-template <class ForwardIterator>
-static ForwardIterator find_first_focussed_component(
-    ForwardIterator begin,
-    ForwardIterator end)
+template <class ForwardRange>
+auto find_first_focussed_component(const ForwardRange &rng)
 {
-    return std::find_if(
-        begin,
-        end,
+    auto const &component_has_focus = 
         [](auto const &comp)
         {
             return comp->has_focus();
-        });
+        };
+
+    return boost::find_if(rng, component_has_focus);
 }
 
-template <class ForwardIterator, class IncrementFunction>
-static boost::optional<bool> increment_focus(
-    bool has_focus,
-    ForwardIterator begin,
-    ForwardIterator end,
+template <class ForwardRange, class IncrementFunction>
+auto increment_focus(
+    const ForwardRange &rng,
     IncrementFunction &&increment)
 {
-    if (has_focus)
-    {
-        begin = find_first_focussed_component(begin, end);
-        assert(begin != end);
-    }
-
-    if ((std::find_if(
-             begin,
-             end,
-             std::forward<IncrementFunction>(increment))
-         == end) == has_focus)
-    {
-        return !has_focus;
-    }
-    else
-    {
-        return {};
-    }
+    return boost::find_if(rng, std::forward<IncrementFunction>(increment));
 }
 
-template <class ForwardIterator>
-static ForwardIterator find_component_at_point(
-    ForwardIterator begin,
-    ForwardIterator end,
+template <class ForwardRange>
+auto find_component_at_point(
+    const ForwardRange &rng,
     terminalpp::point const &location)
 {
-    return std::find_if(
-        begin,
-        end,
+    auto const &has_location_at_point =
         [&location](auto const &comp)
         {
             auto const &position = comp->get_position();
@@ -78,7 +56,9 @@ static ForwardIterator find_component_at_point(
                  && location.x  < position.x + size.width
                  && location.y >= position.y
                  && location.y < position.y + size.height);
-        });
+        };
+
+    return boost::find_if(rng, has_location_at_point);
 }
 
 }
@@ -203,13 +183,14 @@ struct container::impl
     {
         if (!in_focus_operation_)
         {
-            auto comp = std::find_if(
-                components_.begin(),
-                components_.end(),
+            auto const &another_component_has_focus = 
                 [orig = weak_comp.lock()](auto const &comp)
-            {
-                return comp != orig && comp->has_focus();
-            });
+                {
+                    return comp != orig && comp->has_focus();
+                };
+
+            auto comp = 
+                boost::find_if(components_, another_component_has_focus);
 
             if (comp != components_.end())
             {
@@ -298,8 +279,7 @@ struct container::impl
     // ======================================================================
     void handle_common_event(boost::any const &event)
     {
-        auto comp = find_first_focussed_component(
-            components_.begin(), components_.end());
+        auto comp = find_first_focussed_component(components_);
 
         if (comp != components_.end())
         {
@@ -313,8 +293,7 @@ struct container::impl
     void handle_mouse_event(terminalpp::ansi::mouse::report const &report)
     {
         auto const &comp = find_component_at_point(
-            components_.begin(),
-            components_.end(),
+            components_,
             terminalpp::point(report.x_position_, report.y_position_));
 
         if (comp != components_.end())
@@ -505,22 +484,24 @@ void container::do_set_focus()
 
     if (!pimpl_->has_focus_)
     {
-        if (increment_focus(
-            false,
-            pimpl_->components_.begin(),
-            pimpl_->components_.end(),
+        auto const &set_component_focus = 
             [](auto const &comp)
             {
                 comp->set_focus();
                 return comp->has_focus();
-            }))
+            };
+
+        auto const &focussed_component = 
+            increment_focus(pimpl_->components_, set_component_focus);
+
+        pimpl_->has_focus_ = focussed_component != pimpl_->components_.end();
+
+        if (pimpl_->has_focus_)
         {
-            pimpl_->has_focus_ = true;
             on_focus_set();
             on_cursor_state_changed();
             on_cursor_position_changed();
         }
-
     }
 }
 
@@ -536,12 +517,9 @@ void container::do_lose_focus()
         pimpl_->in_focus_operation_ = false;
     };
 
-    auto focussed_component =
-        std::find_if(pimpl_->components_.begin(), pimpl_->components_.end(),
-            [](auto const &component)
-            {
-                return component->has_focus();
-            });
+    
+    auto focussed_component = 
+        find_first_focussed_component(pimpl_->components_);
 
     if (focussed_component != pimpl_->components_.end())
     {
@@ -565,60 +543,37 @@ void container::do_focus_next()
         pimpl_->in_focus_operation_ = false;
     };
 
-    auto focus_change = increment_focus(
-        pimpl_->has_focus_,
-        pimpl_->components_.begin(),
-        pimpl_->components_.end(),
+    bool const had_focus = pimpl_->has_focus_;
+
+    auto const &focus_next_component =
         [](auto const &comp)
         {
             comp->focus_next();
             return comp->has_focus();
-        });
+        };
 
-    if (focus_change)
+    auto const &first_focussed_component = 
+        find_first_focussed_component(pimpl_->components_);
+    
+    // Since we are focussing the next component, we want to look at components
+    // from the first focussed component if there was one, otherwise the
+    // first subcomponent.
+    auto const &increment_from =
+        first_focussed_component == pimpl_->components_.cend()
+      ? pimpl_->components_.cbegin()
+      : first_focussed_component;
+
+    auto const &next_focussed_component = 
+        increment_focus(
+            boost::make_iterator_range(
+                increment_from, pimpl_->components_.cend()),
+            focus_next_component);
+
+    pimpl_->has_focus_ = next_focussed_component != pimpl_->components_.end();
+
+    // Announce a change in focus if that changed.
+    if (had_focus != pimpl_->has_focus_)
     {
-        if (*focus_change)
-        {
-            pimpl_->has_focus_ = true;
-            on_focus_set();
-        }
-        else
-        {
-            pimpl_->has_focus_ = false;
-            on_focus_lost();
-        }
-
-        on_cursor_position_changed();
-        on_cursor_state_changed();
-    }
-}
-
-// ==========================================================================
-// DO_FOCUS_PREVIOUS
-// ==========================================================================
-void container::do_focus_previous()
-{
-    pimpl_->in_focus_operation_ = true;
-
-    BOOST_SCOPE_EXIT_ALL(this)
-    {
-        pimpl_->in_focus_operation_ = false;
-    };
-
-    auto focus_change = increment_focus(
-        pimpl_->has_focus_,
-        pimpl_->components_.rbegin(),
-        pimpl_->components_.rend(),
-        [](auto const &comp)
-        {
-            comp->focus_previous();
-            return comp->has_focus();
-        });
-
-    if (focus_change)
-    {
-        pimpl_->has_focus_ = *focus_change;
-
         if (pimpl_->has_focus_)
         {
             on_focus_set();
@@ -631,6 +586,78 @@ void container::do_focus_previous()
         on_cursor_position_changed();
         on_cursor_state_changed();
     }
+
+    // If we had focus continuously, but the focussed subcomponent changed,
+    // then we also want to announce cursor changes
+    // TODO:
+}
+
+// ==========================================================================
+// DO_FOCUS_PREVIOUS
+// ==========================================================================
+void container::do_focus_previous()
+{
+    using boost::adaptors::reversed;
+    using std::cbegin;
+    using std::cend;
+    
+    pimpl_->in_focus_operation_ = true;
+
+    BOOST_SCOPE_EXIT_ALL(this)
+    {
+        pimpl_->in_focus_operation_ = false;
+    };
+
+    bool const had_focus = pimpl_->has_focus_;
+
+    auto const &focus_previous_component =
+        [](auto const &comp)
+        {
+            comp->focus_previous();
+            return comp->has_focus();
+        };
+
+    auto const &reversed_components = pimpl_->components_ | reversed;
+
+    auto const &first_focussed_component = 
+        find_first_focussed_component(reversed_components);
+    
+    // Since we are focussing the next component, we want to look at components
+    // from the first focussed component if there was one, otherwise the
+    // first subcomponent.
+    auto const &increment_from =
+        first_focussed_component == cend(reversed_components)
+      ? cbegin(reversed_components)
+      : first_focussed_component;
+
+    auto const &previous_focussed_component = 
+        increment_focus(
+            boost::make_iterator_range(
+                increment_from, cend(reversed_components)),
+            focus_previous_component);
+
+    pimpl_->has_focus_ = 
+        previous_focussed_component != cend(reversed_components);
+
+    // Announce a change in focus if that changed.
+    if (had_focus != pimpl_->has_focus_)
+    {
+        if (pimpl_->has_focus_)
+        {
+            on_focus_set();
+        }
+        else
+        {
+            on_focus_lost();
+        }
+
+        on_cursor_position_changed();
+        on_cursor_state_changed();
+    }
+
+    // If we had focus continuously, but the focussed subcomponent changed,
+    // then we also want to announce cursor changes
+    // TODO:
 }
 
 // ==========================================================================
@@ -638,9 +665,7 @@ void container::do_focus_previous()
 // ==========================================================================
 bool container::do_get_cursor_state() const
 {
-    auto comp = find_first_focussed_component(
-        pimpl_->components_.begin(),
-        pimpl_->components_.end());
+    auto comp = find_first_focussed_component(pimpl_->components_);
 
     return comp == pimpl_->components_.end()
          ? false
@@ -652,9 +677,7 @@ bool container::do_get_cursor_state() const
 // ==========================================================================
 terminalpp::point container::do_get_cursor_position() const
 {
-    auto comp = find_first_focussed_component(
-        pimpl_->components_.begin(),
-        pimpl_->components_.end());
+    auto comp = find_first_focussed_component(pimpl_->components_);
 
     return comp == pimpl_->components_.end()
          ? terminalpp::point{}
@@ -670,9 +693,7 @@ void container::do_set_cursor_position(terminalpp::point const &position)
     // make too much sense, but an implementation is required to fulfil the
     // component interface.  Our default implementation sets the relative
     // cursor position in the focussed component.
-    auto comp = find_first_focussed_component(
-        pimpl_->components_.begin(),
-        pimpl_->components_.end());
+    auto comp = find_first_focussed_component(pimpl_->components_);
 
     if (comp != pimpl_->components_.end())
     {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -588,8 +588,17 @@ void container::do_focus_next()
     }
 
     // If we had focus continuously, but the focussed subcomponent changed,
-    // then we also want to announce cursor changes
-    // TODO:
+    // then we also want to announce cursor changes, since even though the
+    // position and state of the cursor in the individual subcomponents hasn't
+    // changed (and therefore they have no reason to send such a signal),
+    // we know that the cursor may have moved about due to focus.
+    if (had_focus 
+     && pimpl_->has_focus_ 
+     && increment_from != next_focussed_component)
+    {
+        on_cursor_position_changed();
+        on_cursor_state_changed();
+    }
 }
 
 // ==========================================================================
@@ -656,8 +665,17 @@ void container::do_focus_previous()
     }
 
     // If we had focus continuously, but the focussed subcomponent changed,
-    // then we also want to announce cursor changes
-    // TODO:
+    // then we also want to announce cursor changes, since even though the
+    // position and state of the cursor in the individual subcomponents hasn't
+    // changed (and therefore they have no reason to send such a signal),
+    // we know that the cursor may have moved about due to focus.
+    if (had_focus 
+     && pimpl_->has_focus_ 
+     && increment_from != previous_focussed_component)
+    {
+        on_cursor_position_changed();
+        on_cursor_state_changed();
+    }
 }
 
 // ==========================================================================

--- a/test/src/container/container_cursor_test.cpp
+++ b/test/src/container/container_cursor_test.cpp
@@ -304,6 +304,25 @@ TEST_F(a_container_with_one_component_that_has_focus, emits_cursor_events_when_s
     ASSERT_EQ(1, cursor_position_changed_count);
 }
 
+TEST_F(a_container_with_two_components_where_the_first_has_focus, emits_cursor_events_when_next_focus_moves_from_one_component_to_the_next)
+{
+    {
+        InSequence s1;
+        EXPECT_CALL(*component0, do_focus_next());
+        EXPECT_CALL(*component0, do_has_focus())
+            .WillRepeatedly(Return(false));
+
+        EXPECT_CALL(*component1, do_focus_next());
+        EXPECT_CALL(*component1, do_has_focus())
+            .WillRepeatedly(Return(true));
+    }
+
+    container.focus_next();
+
+    ASSERT_EQ(1, cursor_position_changed_count);
+    ASSERT_EQ(1, cursor_state_changed_count);
+}
+
 //
 
 TEST_F(a_container_with_one_component, does_not_emit_cursor_events_when_subcomponent_refuses_previous_focus)
@@ -358,6 +377,25 @@ TEST_F(a_container_with_one_component_that_has_focus, emits_cursor_events_when_s
 
     ASSERT_EQ(1, cursor_state_changed_count);
     ASSERT_EQ(1, cursor_position_changed_count);
+}
+
+TEST_F(a_container_with_two_components_where_the_last_has_focus, emits_cursor_events_when_next_focus_moves_from_one_component_to_the_previous)
+{
+    {
+        InSequence s1;
+        EXPECT_CALL(*component1, do_focus_previous());
+        EXPECT_CALL(*component1, do_has_focus())
+            .WillRepeatedly(Return(false));
+
+        EXPECT_CALL(*component0, do_focus_previous());
+        EXPECT_CALL(*component0, do_has_focus())
+            .WillRepeatedly(Return(true));
+    }
+
+    container.focus_previous();
+
+    ASSERT_EQ(1, cursor_position_changed_count);
+    ASSERT_EQ(1, cursor_state_changed_count);
 }
 
 TEST_F(a_container_with_one_component, does_not_emit_cursor_events_when_losing_focus)

--- a/test/src/container/container_focus_next_test.cpp
+++ b/test/src/container/container_focus_next_test.cpp
@@ -6,12 +6,15 @@ using testing::Return;
 
 TEST_F(a_container_with_one_component, calls_focus_next_on_subcomponent_on_focus_next)
 {
+    EXPECT_CALL(*component, do_has_focus())
+        .WillRepeatedly(Return(false));
+
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_next())
             .WillOnce(Invoke(std::ref(component->on_focus_set)));
         EXPECT_CALL(*component, do_has_focus())
-            .WillOnce(Return(true));
+            .WillRepeatedly(Return(true));
     }
 
     container.focus_next();
@@ -23,6 +26,9 @@ TEST_F(a_container_with_one_component, calls_focus_next_on_subcomponent_on_focus
 
 TEST_F(a_container_with_one_component, that_refuses_focus_refuses_focus_on_focus_next)
 {
+    EXPECT_CALL(*component, do_has_focus())
+        .WillRepeatedly(Return(false));
+        
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_next());
@@ -39,16 +45,21 @@ TEST_F(a_container_with_one_component, that_refuses_focus_refuses_focus_on_focus
 
 TEST_F(a_container_with_two_components, skips_components_that_refuse_focus_next_on_focus_next)
 {
+    EXPECT_CALL(*component0, do_has_focus())
+        .WillRepeatedly(Return(false));
+    EXPECT_CALL(*component1, do_has_focus())
+        .WillRepeatedly(Return(false));
+
     {
         InSequence s1;
         EXPECT_CALL(*component0, do_focus_next());
         EXPECT_CALL(*component0, do_has_focus())
-            .WillOnce(Return(false));
+            .WillRepeatedly(Return(false));
 
         EXPECT_CALL(*component1, do_focus_next())
             .WillOnce(Invoke(std::ref(component1->on_focus_set)));
         EXPECT_CALL(*component1, do_has_focus())
-            .WillOnce(Return(true));
+            .WillRepeatedly(Return(true));
     }
 
     container.focus_next();

--- a/test/src/container/container_focus_previous_test.cpp
+++ b/test/src/container/container_focus_previous_test.cpp
@@ -6,6 +6,9 @@ using testing::Return;
 
 TEST_F(a_container_with_one_component, calls_focus_previous_on_subcomponent_on_focus_previous)
 {
+    EXPECT_CALL(*component, do_has_focus())
+        .WillRepeatedly(Return(false));
+        
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_previous())
@@ -23,6 +26,9 @@ TEST_F(a_container_with_one_component, calls_focus_previous_on_subcomponent_on_f
 
 TEST_F(a_container_with_one_component, that_refuses_focus_refuses_focus_on_focus_previous)
 {
+    EXPECT_CALL(*component, do_has_focus())
+        .WillRepeatedly(Return(false));
+        
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_previous());
@@ -39,16 +45,21 @@ TEST_F(a_container_with_one_component, that_refuses_focus_refuses_focus_on_focus
 
 TEST_F(a_container_with_two_components, skips_components_that_refuse_focus_previous_on_focus_previous)
 {
+    EXPECT_CALL(*component1, do_has_focus())
+        .WillRepeatedly(Return(false));
+    EXPECT_CALL(*component0, do_has_focus())
+        .WillRepeatedly(Return(false));
+        
     {
         InSequence s1;
         EXPECT_CALL(*component1, do_focus_previous());
         EXPECT_CALL(*component1, do_has_focus())
-            .WillOnce(Return(false));
+            .WillRepeatedly(Return(false));
 
         EXPECT_CALL(*component0, do_focus_previous())
             .WillOnce(Invoke(std::ref(component0->on_focus_set)));
         EXPECT_CALL(*component0, do_has_focus())
-            .WillOnce(Return(true));
+            .WillRepeatedly(Return(true));
     }
 
     container.focus_previous();

--- a/test/src/container/container_test.hpp
+++ b/test/src/container/container_test.hpp
@@ -144,9 +144,11 @@ protected :
 
         {
             InSequence s1;
+            EXPECT_CALL(*component0, do_has_focus())
+                .WillRepeatedly(Return(false));
             EXPECT_CALL(*component0, do_focus_next());
             EXPECT_CALL(*component0, do_has_focus())
-                .WillOnce(Return(true));
+                .WillRepeatedly(Return(true));
         }
 
         container.focus_next();
@@ -168,9 +170,11 @@ protected :
 
         {
             InSequence s1;
+            EXPECT_CALL(*component1, do_has_focus())
+                .WillRepeatedly(Return(false));
             EXPECT_CALL(*component1, do_focus_previous());
             EXPECT_CALL(*component1, do_has_focus())
-                .WillOnce(Return(true));
+                .WillRepeatedly(Return(true));
         }
 
         container.focus_previous();
@@ -206,9 +210,11 @@ protected :
 
         {
             InSequence s1;
+            EXPECT_CALL(*component0, do_has_focus())
+                .WillRepeatedly(Return(false));
             EXPECT_CALL(*component0, do_focus_next());
             EXPECT_CALL(*component0, do_has_focus())
-                .WillOnce(Return(true));
+                .WillRepeatedly(Return(true));
         }
 
         container.focus_next();
@@ -230,9 +236,11 @@ protected :
 
         {
             InSequence s1;
+            EXPECT_CALL(*component2, do_has_focus())
+                .WillRepeatedly(Return(false));
             EXPECT_CALL(*component2, do_focus_previous());
             EXPECT_CALL(*component2, do_has_focus())
-                .WillOnce(Return(true));
+                .WillRepeatedly(Return(true));
         }
 
         container.focus_previous();


### PR DESCRIPTION
Fixes an issue where incrementing focus of a container (through either focus_next() or focus_previous) did not announce changing cursor position or state when moving between subcomponents.

Fixes #158

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/160)
<!-- Reviewable:end -->
