### PR TITLE
Containers now emit cursor events when focus changes from one subcomponent to another

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -586,6 +586,9 @@ private:
                 has_focus_ = true;
                 self_.on_focus_set();
             }
+
+            self_.on_cursor_position_changed();
+            self_.on_cursor_state_changed();
         }
     }
 

--- a/test/src/container/container_subcomponent_focus_test.cpp
+++ b/test/src/container/container_subcomponent_focus_test.cpp
@@ -34,6 +34,34 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, removes_focus_
     ASSERT_EQ(0, focus_lost_count);
 }
 
+TEST_F(a_container_with_two_components_where_the_first_has_focus, announces_cursor_state_and_position_change_when_the_second_component_takes_focus)
+{
+    {
+        testing::InSequence s1;
+        ON_CALL(*component0, do_has_focus())
+            .WillByDefault(Return(true));
+        ON_CALL(*component0, do_lose_focus())
+            .WillByDefault(Invoke(std::ref(component0->on_focus_lost)));
+        ON_CALL(*component0, do_has_focus())
+            .WillByDefault(Return(false));
+    }
+
+    {
+        testing::InSequence s2;
+        ON_CALL(*component1, do_has_focus())
+            .WillByDefault(Return(false));
+        ON_CALL(*component1, do_set_focus())
+            .WillByDefault(Invoke(std::ref(component0->on_focus_set)));
+        ON_CALL(*component1, do_has_focus())
+            .WillByDefault(Return(true));
+    }
+
+    component1->set_focus();
+
+    ASSERT_EQ(1, cursor_position_changed_count);
+    ASSERT_EQ(1, cursor_state_changed_count);
+}
+
 TEST_F(a_container_with_two_components_where_the_last_has_focus, removes_focus_from_the_second_component_when_the_first_component_sets_focus)
 {
     EXPECT_CALL(*component1, do_has_focus())


### PR DESCRIPTION
Fixed #176

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/177)
<!-- Reviewable:end -->
