### PR TITLE
Reanchor viewport on size change#182

### DIFF
--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -27,7 +27,7 @@ private:
     /// function in order to set the size of the component in a custom
     /// manner.
     //* =====================================================================
-    void do_set_size(terminalpp::extent const &size) ;
+    void do_set_size(terminalpp::extent const &size) override;
 
     //* =====================================================================
     /// \brief Called by get_preferred_size().  Derived classes must override

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -183,7 +183,28 @@ struct viewport::impl
         auto const old_cursor_position = cursor_position_;
         auto const old_viewport_position = anchor_position_;
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
+        auto const tracked_component_size = tracked_component_->get_size();
         auto const viewport_size = self_.get_size();
+
+        // Because size changes first match up the size of the tracked
+        // component with the size of the viewport, it must be the case that
+        // the tracked component's size is at least as large as the viewport
+        // itself.
+        assert(tracked_component_size.width >= viewport_size.width);
+        assert(tracked_component_size.height >= viewport_size.height);
+
+        // If the viewport has changed its size, look to see if the tracked
+        // component is contained entirely in the viewport.  If not, then
+        // adjust the anchor appropriately.
+        if (anchor_position_.x + viewport_size.width > tracked_component_size.width)
+        {
+            anchor_position_.x = tracked_component_size.width - viewport_size.width;
+        }
+
+        if (anchor_position_.y + viewport_size.height > tracked_component_size.height)
+        {
+            anchor_position_.y = tracked_component_size.height - viewport_size.height;
+        }
 
         // Check to see if the tracked cursor has scrolled off an edge of the
         // viewport.  If so, then the anchor position must change just enough

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -93,17 +93,6 @@ INSTANTIATE_TEST_CASE_P(
     )
 );
 
-namespace 
-{
-
-class a_viewport : 
-    public a_viewport_with_mock_tracked_component,
-    public testing::Test
-{
-};
-
-}
-
 TEST_F(a_viewport, with_a_size_larger_than_the_preferred_size_of_the_tracked_component_sets_the_tracked_component_to_the_larger_size)
 {
     auto const viewport_size = terminalpp::extent{5, 5};

--- a/test/src/viewport/viewport_test.hpp
+++ b/test/src/viewport/viewport_test.hpp
@@ -4,8 +4,23 @@
 class a_viewport_with_mock_tracked_component
 {
 protected:
+    a_viewport_with_mock_tracked_component()
+    {
+        using testing::SaveArg;
+        using testing::ReturnPointee;
+        using testing::_;
+
+        ON_CALL(*tracked_component_, do_get_size())
+            .WillByDefault(ReturnPointee(&tracked_component_size_));
+        ON_CALL(*tracked_component_, do_set_size(_))
+            .WillByDefault(SaveArg<0>(&tracked_component_size_));
+    }
+
     std::shared_ptr<mock_component> tracked_component_ = make_mock_component();
     std::shared_ptr<munin::viewport> viewport_ = munin::make_viewport(tracked_component_);
+
+private:
+    terminalpp::extent tracked_component_size_;
 };
 
 template <typename TestData>
@@ -44,4 +59,10 @@ protected:
 
 private:
     terminalpp::point tracked_cursor_position_;
+};
+
+class a_viewport : 
+    public a_viewport_with_mock_tracked_component,
+    public testing::Test
+{
 };


### PR DESCRIPTION
When the size of the viewport changes (in particular, when it expands east or south), then some of the area may be uncovered by the tracked component.  This may lead to graphical artifacts if there was previously something in the uncovered space.

There are two possible solutions to this.  One is to expand the tracked component such that its size is always at least anchor position + viewport size.  This would grow the component to meet the changing viewport size.

This PR takes the alternative approach: to re-anchor the viewport in such a case.  This gives the impression that the tracked component is scrolling with the viewport.

Closes #182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/183)
<!-- Reviewable:end -->
