### PR TITLE
Memory optimizations

### DIFF
--- a/include/munin/basic_component.hpp
+++ b/include/munin/basic_component.hpp
@@ -17,11 +17,6 @@ public :
     //* =====================================================================
     basic_component();
 
-    //* =====================================================================
-    /// \brief Destructor
-    //* =====================================================================
-    ~basic_component() override;
-
 protected :
     //* =====================================================================
     /// \brief Returns true if it is allowed for the component to receive
@@ -133,8 +128,8 @@ protected :
     nlohmann::json do_to_json() const override;
 
 private :
-    struct impl;
-    std::shared_ptr<impl> pimpl_;
+    terminalpp::rectangle bounds_;
+    bool has_focus_;
 };
 
 }

--- a/include/munin/brush.hpp
+++ b/include/munin/brush.hpp
@@ -33,11 +33,6 @@ public :
     explicit brush(std::vector<terminalpp::string> pattern);
 
     //* =====================================================================
-    /// \brief Destructor
-    //* =====================================================================
-    ~brush() override;
-
-    //* =====================================================================
     /// \brief Sets the pattern to the default pattern (i.e. whitespace)
     //* =====================================================================
     void set_pattern();
@@ -90,8 +85,7 @@ protected :
     nlohmann::json do_to_json() const override;
 
 private :
-    struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::vector<terminalpp::string> pattern_;
 };
 
 //* =========================================================================

--- a/include/munin/filled_box.hpp
+++ b/include/munin/filled_box.hpp
@@ -13,6 +13,8 @@ namespace munin {
 class MUNIN_EXPORT filled_box : public munin::basic_component
 {
 public :
+    using fill_function_type = terminalpp::element (render_surface &);
+
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
@@ -21,14 +23,8 @@ public :
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    explicit filled_box(
-        std::function<terminalpp::element (render_surface &)> fill_function);
+    explicit filled_box(std::function<fill_function_type> fill_function);
     
-    //* =====================================================================
-    /// \brief Destructor
-    //* =====================================================================
-    ~filled_box() override;
-
     //* =====================================================================
     /// \brief Sets the preferred size of this box.  The default is (1,1).
     //* =====================================================================
@@ -72,8 +68,8 @@ protected :
     nlohmann::json do_to_json() const override;
 
 private :
-    struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::function<fill_function_type> fill_function_;
+    terminalpp::extent preferred_size_;
 };
 
 //* =========================================================================
@@ -87,6 +83,6 @@ std::shared_ptr<filled_box> make_fill(terminalpp::element const &fill);
 //* =========================================================================
 MUNIN_EXPORT
 std::shared_ptr<filled_box> make_fill(
-    std::function<terminalpp::element (render_surface&)> fill_function);
+    std::function<filled_box::fill_function_type> fill_function);
 
 }

--- a/include/munin/framed_component.hpp
+++ b/include/munin/framed_component.hpp
@@ -16,13 +16,8 @@ public :
     /// \brief Constructor
     //* =====================================================================
     framed_component(
-        std::shared_ptr<frame> const &outer_frame,
-        std::shared_ptr<component> const &inner_component);
-
-    //* =====================================================================
-    /// \brief Destructor
-    //* =====================================================================
-    ~framed_component() override;
+        std::shared_ptr<frame> outer_frame,
+        std::shared_ptr<component> inner_component);
 
 protected :
     //* =====================================================================
@@ -39,8 +34,8 @@ protected :
     nlohmann::json do_to_json() const override;
 
 private :
-    struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::shared_ptr<frame> frame_;
+    std::shared_ptr<component> inner_component_;
 };
 
 //* =========================================================================
@@ -48,7 +43,7 @@ private :
 //* =========================================================================
 MUNIN_EXPORT
 std::shared_ptr<framed_component> make_framed_component(
-    std::shared_ptr<frame> const &outer_frame,
-    std::shared_ptr<component> const &inner_component);
+    std::shared_ptr<frame> outer_frame,
+    std::shared_ptr<component> inner_component);
 
 }

--- a/include/munin/image.hpp
+++ b/include/munin/image.hpp
@@ -105,7 +105,7 @@ protected :
 
 private :
     struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::unique_ptr<impl> pimpl_;
 };
 
 //* =========================================================================

--- a/include/munin/titled_frame.hpp
+++ b/include/munin/titled_frame.hpp
@@ -63,7 +63,7 @@ protected :
 
 private :
     struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::unique_ptr<impl> pimpl_;
 };
 
 //* =========================================================================

--- a/include/munin/toggle_button.hpp
+++ b/include/munin/toggle_button.hpp
@@ -15,6 +15,11 @@ public :
     explicit toggle_button(bool checked = false);
 
     //* =====================================================================
+    /// \brief Destructor
+    //* =====================================================================
+    ~toggle_button() override;
+
+    //* =====================================================================
     /// \brief Sets the toggle state of the button.
     //* =====================================================================
     void set_toggle_state(bool checked);
@@ -41,7 +46,7 @@ protected :
 
 private :
     struct impl;
-    std::shared_ptr<impl> pimpl_;
+    std::unique_ptr<impl> pimpl_;
 };
 
 //* =========================================================================

--- a/include/munin/window.hpp
+++ b/include/munin/window.hpp
@@ -62,7 +62,7 @@ public :
     
 private :
     class impl;
-    std::shared_ptr<impl> pimpl_;
+    std::unique_ptr<impl> pimpl_;
 };
 
 }

--- a/src/filled_box.cpp
+++ b/src/filled_box.cpp
@@ -5,15 +5,6 @@
 namespace munin {
 
 // ==========================================================================
-// FILLED_BOX::IMPLEMENTATION STRUCTURE
-// ==========================================================================
-struct filled_box::impl
-{
-    std::function<terminalpp::element (render_surface &)> fill_function_;
-    terminalpp::extent  preferred_size_;
-};
-
-// ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
 filled_box::filled_box(terminalpp::element const &element)
@@ -24,18 +15,9 @@ filled_box::filled_box(terminalpp::element const &element)
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
-filled_box::filled_box(
-    std::function<terminalpp::element (render_surface &)> fill_function)
-  : pimpl_(std::make_shared<impl>())
-{
-    pimpl_->fill_function_  = std::move(fill_function);
-    pimpl_->preferred_size_ = terminalpp::extent(1, 1);
-}
-
-// ==========================================================================
-// DESTRUCTOR
-// ==========================================================================
-filled_box::~filled_box()
+filled_box::filled_box(std::function<fill_function_type> fill_function)
+  : fill_function_(std::move(fill_function)),
+    preferred_size_({1, 1})
 {
 }
 
@@ -52,7 +34,7 @@ bool filled_box::do_can_receive_focus() const
 // ==========================================================================
 void filled_box::set_preferred_size(terminalpp::extent preferred_size)
 {
-    pimpl_->preferred_size_ = preferred_size;
+    preferred_size_ = preferred_size;
     on_preferred_size_changed();
 }
 
@@ -61,7 +43,7 @@ void filled_box::set_preferred_size(terminalpp::extent preferred_size)
 // ==========================================================================
 terminalpp::extent filled_box::do_get_preferred_size() const
 {
-    return pimpl_->preferred_size_;
+    return preferred_size_;
 }
 
 // ==========================================================================
@@ -70,7 +52,7 @@ terminalpp::extent filled_box::do_get_preferred_size() const
 void filled_box::do_draw(
     render_surface &surface, terminalpp::rectangle const &region) const
 {
-    auto const element = pimpl_->fill_function_(surface);
+    auto const element = fill_function_(surface);
     
     terminalpp::for_each_in_region(
         surface,

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1,6 +1,7 @@
 #include "munin/image.hpp"
 #include "munin/detail/json_adaptors.hpp"
 #include "munin/render_surface.hpp"
+#include <boost/make_unique.hpp>
 #include <algorithm>
 #include <utility>
 
@@ -146,7 +147,7 @@ image::image(terminalpp::string content, terminalpp::element fill)
 image::image(
     std::vector<terminalpp::string> content,
     terminalpp::element fill)
-  : pimpl_(std::make_shared<impl>())
+  : pimpl_(boost::make_unique<impl>())
 {
     // There is a special case for "empty" content, where the content is
     // a single empty string.  In this case, it is not stored, and is as if

--- a/src/solid_frame.cpp
+++ b/src/solid_frame.cpp
@@ -3,6 +3,7 @@
 #include "munin/compass_layout.hpp"
 #include "munin/render_surface.hpp"
 #include "munin/view.hpp"
+#include <boost/make_unique.hpp>
 
 namespace munin {
 
@@ -56,7 +57,7 @@ struct solid_frame::impl
 // CONSTRUCTOR
 // ==========================================================================
 solid_frame::solid_frame()
-  : pimpl_(std::make_shared<impl>(*this))
+  : pimpl_(boost::make_unique<impl>(*this))
 {
     auto &attr = pimpl_->current_attribute;
     

--- a/src/titled_frame.cpp
+++ b/src/titled_frame.cpp
@@ -3,6 +3,7 @@
 #include "munin/compass_layout.hpp"
 #include "munin/image.hpp"
 #include "munin/view.hpp"
+#include <boost/make_unique.hpp>
 
 namespace munin {
 
@@ -62,7 +63,7 @@ struct titled_frame::impl
 // CONSTRUCTOR
 // ==========================================================================
 titled_frame::titled_frame(terminalpp::string const &title)
-  : pimpl_(std::make_shared<impl>(*this))
+  : pimpl_(boost::make_unique<impl>(*this))
 {
     pimpl_->title_text = title;
     pimpl_->title = make_image(pimpl_->title_text);

--- a/src/toggle_button.cpp
+++ b/src/toggle_button.cpp
@@ -5,6 +5,7 @@
 #include "munin/solid_frame.hpp"
 #include <terminalpp/ansi/mouse.hpp>
 #include <terminalpp/virtual_key.hpp>
+#include <boost/make_unique.hpp>
 
 namespace munin {
 
@@ -21,7 +22,7 @@ struct toggle_button::impl
 // CONSTRUCTOR
 // ==========================================================================
 toggle_button::toggle_button(bool checked)
-  : pimpl_(std::make_shared<impl>())
+  : pimpl_(boost::make_unique<impl>())
 {
     pimpl_->fill_ = 
         make_fill([this](render_surface&) -> terminalpp::element
@@ -38,6 +39,11 @@ toggle_button::toggle_button(bool checked)
         make_solid_frame(),
         pimpl_->fill_));
 }
+
+// ==========================================================================
+// DESTRUCTOR
+// ==========================================================================
+toggle_button::~toggle_button() = default;
 
 // ==========================================================================
 // SET_TOGGLE_STATE

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -328,9 +328,7 @@ private:
 // CONSTRUCTOR
 // ==========================================================================
 viewport::viewport(std::shared_ptr<component> tracked_component)
-  : pimpl_(boost::make_unique<impl>(
-        std::ref(*this), 
-        std::move(tracked_component)))
+  : pimpl_(boost::make_unique<impl>(*this, std::move(tracked_component)))
 {
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -4,6 +4,7 @@
 #include "munin/detail/json_adaptors.hpp"
 #include <terminalpp/screen.hpp>
 #include <terminalpp/terminal.hpp>
+#include <boost/make_unique.hpp>
 
 namespace munin {
 
@@ -50,7 +51,7 @@ struct window::impl
 // CONSTRUCTOR
 // ==========================================================================
 window::window(std::shared_ptr<component> content)
-  : pimpl_(std::make_shared<impl>(std::ref(*this)))
+  : pimpl_(std::make_unique<impl>(*this))
 {
     pimpl_->content_ = std::move(content);
     


### PR DESCRIPTION
Removed the pimpl pattern from various frequently-used by supposedly light-weight components.  This reduced the number of memory allocations in the tests by about 2,000 (282,000 -> 280,000).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/185)
<!-- Reviewable:end -->
