### PR TITLE
Migrate to new JSON package location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ target_include_directories(munin
 target_link_libraries(munin
     PUBLIC
         CONAN_PKG::terminalpp
-        CONAN_PKG::jsonformoderncpp
+        CONAN_PKG::nlohmann_json
         CONAN_PKG::boost
 )
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class MuninConan(ConanFile):
     default_options = {"shared": False, "coverage": False, "sanitize": "off"}    
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     requires = ("terminalpp/[>=1.4.0]@kazdragon/conan-public",
-                "jsonformoderncpp/[>=3.3.0]",
+                "nlohmann_json/[>=3.3.0]",
                 "boost/[>=1.69]")
     build_requires = ("gtest/[>=1.8.1]")
     generators = "cmake"


### PR DESCRIPTION
Now builds with nlohmann_json instead of jsonformoderncpp, as the
latter is deprecated in favour of the former.

Closes #192.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/195)
<!-- Reviewable:end -->
