### PR TITLE
Lists now track their "cursor" position

### DIFF
--- a/include/munin/list.hpp
+++ b/include/munin/list.hpp
@@ -55,6 +55,13 @@ private:
     terminalpp::extent do_get_preferred_size() const override;
 
     //* =====================================================================
+    /// \brief Called by get_cursor_position().  Derived classes must
+    /// override this function in order to return the cursor position in
+    /// a custom manner.
+    //* =====================================================================
+    terminalpp::point do_get_cursor_position() const override;
+
+    //* =====================================================================
     /// \brief Called by draw().  Derived classes must override this function
     /// in order to draw onto the passed context.  A component must only draw
     /// the part of itself specified by the region.

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -44,6 +44,16 @@ struct list::impl
     }
 
     // ======================================================================
+    // GET_CURSOR_POSITION
+    // ======================================================================
+    terminalpp::point get_cursor_position() const
+    {
+        return selected_item_index_
+             ? terminalpp::point(0, *selected_item_index_)
+             : terminalpp::point(0, 0);
+    }
+
+    // ======================================================================
     // DRAW
     // ======================================================================
     void draw(
@@ -208,6 +218,7 @@ void list::select_item(boost::optional<int> const &index)
 
     pimpl_->selected_item_index_ = index;
     on_item_changed();
+    on_cursor_position_changed();
     on_redraw({{{}, get_size()}});
 }
 
@@ -236,6 +247,14 @@ void list::set_items(std::vector<terminalpp::string> const &items)
 terminalpp::extent list::do_get_preferred_size() const
 {
     return pimpl_->get_preferred_size();
+}
+
+// ==========================================================================
+// DO_GET_CURSOR_POSITION
+// ==========================================================================
+terminalpp::point list::do_get_cursor_position() const
+{
+    return pimpl_->get_cursor_position();
 }
 
 // ==========================================================================

--- a/test/src/list/list_test.cpp
+++ b/test/src/list/list_test.cpp
@@ -139,6 +139,16 @@ TEST_F(a_new_list, ignores_the_down_key)
     ASSERT_FALSE(list_->get_selected_item_index().is_initialized());
 }
 
+TEST_F(a_new_list, has_a_zero_cursor_position)
+{
+    ASSERT_EQ(terminalpp::point(0, 0), list_->get_cursor_position());
+}
+
+TEST_F(a_new_list, has_a_disabled_cursor)
+{
+    ASSERT_FALSE(list_->get_cursor_state());
+}
+
 namespace {
 
 class a_list_with_an_item : public a_new_list
@@ -214,6 +224,19 @@ TEST_F(a_list_with_an_item, sends_item_changed_signal_when_an_item_is_selected)
 
     list_->select_item(0);
     ASSERT_TRUE(item_changed);
+}
+
+TEST_F(a_list_with_an_item, signals_a_changed_cursor_position_when_an_item_is_selected)
+{
+    bool cursor_position_changed = false;
+    list_->on_cursor_position_changed.connect(
+        [&cursor_position_changed]()
+        {
+            cursor_position_changed = true;
+        });
+
+    list_->select_item(0);
+    ASSERT_TRUE(cursor_position_changed);
 }
 
 TEST_F(a_list_with_an_item, selects_the_item_when_it_is_clicked)
@@ -681,6 +704,11 @@ TEST_F(a_list_with_two_items_and_the_first_selected, deselects_the_first_item_wh
     ASSERT_FALSE(selected_item_index.is_initialized());
 }
 
+TEST_F(a_list_with_two_items_and_the_first_selected, has_a_cursor_position_on_the_home_row)
+{
+    ASSERT_EQ(terminalpp::point(0, 0), list_->get_cursor_position());
+}
+
 namespace {
 
 class a_list_with_two_items_and_the_second_selected : public a_list_with_two_items
@@ -963,4 +991,9 @@ TEST_F(a_list_with_two_items_and_the_second_selected, when_items_are_set_to_a_on
     auto const selected_item_index = list_->get_selected_item_index();
     ASSERT_TRUE(selected_item_index.is_initialized());
     ASSERT_EQ(0, *selected_item_index);
+}
+
+TEST_F(a_list_with_two_items_and_the_second_selected, has_a_cursor_position_on_the_second_row)
+{
+    ASSERT_EQ(terminalpp::point(0, 1), list_->get_cursor_position());
 }


### PR DESCRIPTION
The cursor position is the first cell of the row that is selected,
or (0,0) if no cursor is selected.  This ensures that the selected
item is always on display in a viewport.

Closes #202

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/203)
<!-- Reviewable:end -->
