### PR TITLE
Lists signal a cursor position change when setting the items

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -237,6 +237,7 @@ void list::set_items(std::vector<terminalpp::string> const &items)
       : boost::optional<int>(pimpl_->items_.size() - 1);
       
     on_item_changed();
+    on_cursor_position_changed();
     on_preferred_size_changed();
     on_redraw({{{}, get_size()}});
 }

--- a/test/src/list/list_test.cpp
+++ b/test/src/list/list_test.cpp
@@ -113,6 +113,21 @@ TEST_F(a_new_list, signals_a_preferred_size_change_when_setting_the_list_items)
     ASSERT_TRUE(preferred_size_changed);    
 }
 
+TEST_F(a_new_list, signals_a_cursor_position_change_when_setting_the_list_items)
+{
+    bool cursor_position_changed = false;
+    list_->on_cursor_position_changed.connect(
+        [&cursor_position_changed]()
+        {
+            cursor_position_changed = true;
+        });
+
+    std::vector<terminalpp::string> items = {"test"_ts};
+    list_->set_items(items);
+    ASSERT_TRUE(cursor_position_changed);
+}
+
+
 TEST_F(a_new_list, can_be_clicked)
 {
     list_->event(


### PR DESCRIPTION
If a list is in a viewport, and is somewhere at the bottom, then
setting the list of items might involve moving to an item that
is no longer in view.  Signalling that the cursor position has
changed will cause the viewport to update its position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/204)
<!-- Reviewable:end -->
