### PR TITLE
Fix all warnings on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,11 @@ set_target_properties(munin
         SOVERSION ${MUNIN_VERSION}
 )        
 
+target_compile_options(munin
+    PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+)
+
 generate_export_header(munin
     EXPORT_FILE_NAME
         "${PROJECT_SOURCE_DIR}/include/munin/export.hpp"
@@ -304,6 +309,11 @@ target_include_directories(munin_tester
 
 target_link_libraries(munin_tester
     ${MUNIN_TESTER_LIBRARIES}
+)
+
+target_compile_options(munin_tester
+    PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
 )
 
 add_test(munin_test munin_tester)

--- a/src/brush.cpp
+++ b/src/brush.cpp
@@ -79,8 +79,9 @@ terminalpp::extent brush::do_get_preferred_size() const
     return pattern_.empty()
          ? terminalpp::extent(1, 1)
          : terminalpp::extent(
-               *boost::max_element(pattern_ | transformed(size)),
-               pattern_.size());
+               terminalpp::coordinate_type(
+                   *boost::max_element(pattern_ | transformed(size))),
+               terminalpp::coordinate_type(pattern_.size()));
 }
 
 // ==========================================================================

--- a/src/edit.cpp
+++ b/src/edit.cpp
@@ -47,7 +47,8 @@ struct edit::impl
                     && !is_control_element(element);
             };
             
-        terminalpp::coordinate_type const old_content_size = content.size();
+        auto const old_content_size = 
+            terminalpp::coordinate_type(content.size());
         
         auto const insertable_text = 
             text | boost::adaptors::filtered(is_visible_in_edits);
@@ -59,9 +60,8 @@ struct edit::impl
             begin(insertable_text),
             end(insertable_text));
         
-        terminalpp::coordinate_type const new_content_size = content.size();
-        terminalpp::coordinate_type const added_content_size = 
-            new_content_size - old_content_size;
+        auto const new_content_size = terminalpp::coordinate_type(content.size());
+        auto const added_content_size = new_content_size - old_content_size;
 
         self_.set_cursor_position({
             cursor_position.x + added_content_size,
@@ -113,7 +113,7 @@ struct edit::impl
                 break;
                 
             case terminalpp::vk::bs:
-                [[fallthrough]];
+                // Fall-through
             case terminalpp::vk::del:
                 handle_backspace();
                 break;
@@ -188,7 +188,8 @@ private:
     // ======================================================================
     void handle_end()
     {
-        terminalpp::coordinate_type rightmost_cursor_position = content.size();
+        auto const rightmost_cursor_position = 
+            terminalpp::coordinate_type(content.size());
         self_.set_cursor_position({
             rightmost_cursor_position, cursor_position.y});
     }
@@ -267,7 +268,9 @@ void edit::insert_text(terminalpp::string const &text)
 // ==========================================================================
 terminalpp::extent edit::do_get_preferred_size() const
 {
-    return terminalpp::extent(pimpl_->content.size() + 1, 1);
+    return terminalpp::extent(
+        terminalpp::coordinate_type(pimpl_->content.size() + 1),
+        1);
 }
 
 // ==========================================================================

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -252,14 +252,15 @@ terminalpp::extent image::do_get_preferred_size() const
     return pimpl_->content_.empty()
          ? terminalpp::extent()
          : terminalpp::extent(
-               std::max_element(
-                   pimpl_->content_.begin(),
-                   pimpl_->content_.end(),
-                   [](auto const &lhs, auto const &rhs)
-                   {
-                       return lhs.size() < rhs.size();
-                   })->size(),
-               pimpl_->content_.size());
+               terminalpp::coordinate_type(
+                   std::max_element(
+                       pimpl_->content_.begin(),
+                       pimpl_->content_.end(),
+                       [](auto const &lhs, auto const &rhs)
+                       {
+                           return lhs.size() < rhs.size();
+                       })->size()),
+               terminalpp::coordinate_type(pimpl_->content_.size()));
 }
 
 // ==========================================================================

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -32,13 +32,13 @@ struct list::impl
             };
         
         auto const preferred_width = 
-            static_cast<terminalpp::coordinate_type>(
+            terminalpp::coordinate_type(
                 items_.empty()
               ? 0
               : *boost::max_element(items_ | transformed(string_size)));
 
         auto const preferred_height = 
-            static_cast<terminalpp::coordinate_type>(items_.size());
+            terminalpp::coordinate_type(items_.size());
 
         return { preferred_width, preferred_height };
     }

--- a/src/status_bar.cpp
+++ b/src/status_bar.cpp
@@ -67,7 +67,8 @@ terminalpp::extent status_bar::do_get_preferred_size() const
 {
     return pimpl_->message_.empty()
          ? terminalpp::extent{1, 1}
-         : terminalpp::extent(pimpl_->message_.size(), 1);
+         : terminalpp::extent{
+               terminalpp::coordinate_type(pimpl_->message_.size()), 1};
 }
 
 // ==========================================================================
@@ -92,20 +93,23 @@ void status_bar::do_draw(
         is_in_frame_0 ? 0 : ((now - frame_1_time) / marquee_frame_time) + 1;
     auto const character_index = frame_number * characters_per_marquee_frame;
 
+    auto const message_width = 
+        terminalpp::coordinate_type(pimpl_->message_.size());
+
     terminalpp::for_each_in_region(
         surface,
         region,
-        [this, character_index](
+        [this, character_index, message_width](
             terminalpp::element &elem,
             terminalpp::coordinate_type column,
             terminalpp::coordinate_type row)
         {
-            elem = (character_index + column) < pimpl_->message_.size()
+            elem = (character_index + column) < message_width
                  ? pimpl_->message_[character_index + column]
                  : ' ';
         });
 
-    if (character_index < pimpl_->message_.size())
+    if (character_index < message_width)
     {
         auto const next_frame_time =
             is_in_frame_0

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -133,7 +133,10 @@ text_area::text_index text_area::get_length() const
 void text_area::insert_text(terminalpp::string const &text)
 {
     insert_text(text, pimpl_->caret_position_);
-    pimpl_->move_caret(pimpl_->caret_position_ + text.size());
+
+    auto const new_caret_position = static_cast<text_area::text_index>(
+        pimpl_->caret_position_ + text.size());
+    pimpl_->move_caret(new_caret_position);
 }
 
 // ==========================================================================

--- a/test/src/brush/new_brush_test.cpp
+++ b/test/src/brush/new_brush_test.cpp
@@ -15,7 +15,13 @@ TEST(a_new_brush_with_a_single_line_pattern, has_a_preferred_size_with_the_width
     auto const pattern = "abcde"_ts;
     munin::brush brush(pattern);
 
-    ASSERT_EQ(terminalpp::extent(pattern.size(), 1), brush.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(pattern.size()),
+            1
+        };
+
+    ASSERT_EQ(expected_preferred_size, brush.get_preferred_size());
 }
 
 TEST(a_new_brush_with_a_multi_line_pattern, has_a_preferred_size_with_the_width_of_the_longest_line_and_height_of_the_number_of_lines)
@@ -28,7 +34,13 @@ TEST(a_new_brush_with_a_multi_line_pattern, has_a_preferred_size_with_the_width_
 
     munin::brush brush(pattern);
 
-    ASSERT_EQ(terminalpp::extent(pattern[1].size(), 2), brush.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(pattern[1].size()),
+            2
+        };
+
+    ASSERT_EQ(expected_preferred_size, brush.get_preferred_size());
 }
 
 TEST(a_new_brush, draws_whitespace_on_the_canvas)

--- a/test/src/image/new_image_test.cpp
+++ b/test/src/image/new_image_test.cpp
@@ -28,7 +28,13 @@ TEST(a_new_image_with_single_line_content, has_a_preferred_size_with_the_width_o
     auto const content = "abcde"_ts;
     munin::image image(content);
 
-    ASSERT_EQ(terminalpp::extent(content.size(), 1), image.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(content.size()),
+            1
+        };
+
+    ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
 
 TEST(a_new_image_with_single_line_content_and_a_fill, has_a_preferred_size_with_the_width_of_that_line)
@@ -37,7 +43,13 @@ TEST(a_new_image_with_single_line_content_and_a_fill, has_a_preferred_size_with_
     auto const content = "abcde"_ts;
     munin::image image(content, terminalpp::element('Y'));
 
-    ASSERT_EQ(terminalpp::extent(content.size(), 1), image.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(content.size()),
+            1
+        };
+
+    ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
 
 TEST(a_new_image_with_empty_multi_line_content, has_a_zero_preferred_size)
@@ -57,7 +69,13 @@ TEST(a_new_image_with_multi_line_content, has_a_preferred_size_with_the_width_of
 
     munin::image image(content);
 
-    ASSERT_EQ(terminalpp::extent(content[1].size(), 2), image.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(content[1].size()),
+            2
+        };
+
+    ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
 
 TEST(a_new_image_with_multi_line_content_and_a_fill, has_a_preferred_size_with_the_width_of_the_longest_line_and_height_of_the_number_of_lines)
@@ -70,7 +88,13 @@ TEST(a_new_image_with_multi_line_content_and_a_fill, has_a_preferred_size_with_t
 
     munin::image image(content, 'Z');
 
-    ASSERT_EQ(terminalpp::extent(content[1].size(), 2), image.get_preferred_size());
+    auto const expected_preferred_size =
+        terminalpp::extent{
+            static_cast<terminalpp::coordinate_type>(content[1].size()),
+            2
+        };
+
+    ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
 
 TEST(a_new_image, draws_whitespace_on_the_canvas)

--- a/test/src/list/list_test.cpp
+++ b/test/src/list/list_test.cpp
@@ -188,7 +188,7 @@ TEST_F(a_list_with_an_item, has_no_selected_item)
 TEST_F(a_list_with_an_item, has_a_preferred_size_of_that_item)
 {
     auto const expected_preferred_size = terminalpp::extent{
-        static_cast<terminalpp::coordinate_type>(item_text.size()),
+        terminalpp::coordinate_type(item_text.size()),
         1
     };
 
@@ -435,7 +435,7 @@ protected:
 TEST_F(a_list_with_two_items, has_a_preferred_size_of_the_largest_item_and_the_number_of_items)
 {
     auto const expected_preferred_size = terminalpp::extent{
-        static_cast<terminalpp::coordinate_type>(item_text1.size()),
+        terminalpp::coordinate_type(item_text1.size()),
         2
     };
 

--- a/test/src/status_bar/status_bar_test.cpp
+++ b/test/src/status_bar/status_bar_test.cpp
@@ -74,7 +74,12 @@ TEST_F(a_new_status_bar, has_a_preferred_size_of_the_message_when_a_message_is_s
 
     status_bar_->set_message(message);
 
-    auto const expected_size = terminalpp::extent(message.size(), 1);
+    auto const expected_size =
+        terminalpp::extent{
+            terminalpp::coordinate_type(message.size()),
+            1
+    };
+
     ASSERT_TRUE(preferred_size.is_initialized());
     ASSERT_EQ(expected_size, *preferred_size);
 }


### PR DESCRIPTION
There were several warnings generated, including signed/unsigned mismatches and potential losses of data.

Mostly, these have been silenced, since I would require things like screens of more than 2 billion elements for this to become a problem.  And in those cases, I already have a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/206)
<!-- Reviewable:end -->
