### PR TITLE
Disabled Conan CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       run: ctest -C $BUILD_TYPE || (cat Testing/Temporary/LastTest.log && false)
 
   build-conan:
+    if: ${{ false }} # disable due to conan repo being defunct
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
This is due to the repository where Terminal++ was kept being defunct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/213)
<!-- Reviewable:end -->
