### PR TITLE
Removed build-conan as a ci dependency on build-docs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
 #   Only build documentation for valid builds on master.
-    needs: [build, build-conan]
+    needs: [build] # Todo: add build-conan as dependency when it is restored
     if: github.ref == 'refs/heads/master'
 
     steps:


### PR DESCRIPTION
build-conan is currently disabled, so this was also disabling documentation generation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/214)
<!-- Reviewable:end -->
