### PR TITLE
Implement scrolling areas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(munin
         include/munin/list.hpp
         include/munin/null_layout.hpp
         include/munin/render_surface.hpp
+        include/munin/scroll_frame.hpp
         include/munin/solid_frame.hpp
         include/munin/status_bar.hpp
         include/munin/text_area.hpp
@@ -176,6 +177,7 @@ target_sources(munin
         src/list.cpp
         src/null_layout.cpp
         src/render_surface.cpp
+        src/scroll_frame.cpp
         src/solid_frame.cpp
         src/status_bar.cpp
         src/text_area.cpp
@@ -290,6 +292,7 @@ target_sources(munin_tester
         test/src/null_layout/null_layout_test.cpp
         test/src/render_surface/render_surface_capabilities_test.cpp
         test/src/render_surface/render_surface_test.cpp
+        test/src/scroll_frame/scroll_frame_test.cpp
         test/src/solid_frame/solid_frame_json_test.cpp
         test/src/solid_frame/solid_frame_test.cpp
         test/src/status_bar/status_bar_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(munin
         include/munin/list.hpp
         include/munin/null_layout.hpp
         include/munin/render_surface.hpp
+        include/munin/scroll_pane.hpp
         include/munin/scroll_frame.hpp
         include/munin/solid_frame.hpp
         include/munin/status_bar.hpp
@@ -177,6 +178,7 @@ target_sources(munin
         src/list.cpp
         src/null_layout.cpp
         src/render_surface.cpp
+        src/scroll_pane.cpp
         src/scroll_frame.cpp
         src/solid_frame.cpp
         src/status_bar.cpp
@@ -293,6 +295,7 @@ target_sources(munin_tester
         test/src/render_surface/render_surface_capabilities_test.cpp
         test/src/render_surface/render_surface_test.cpp
         test/src/scroll_frame/scroll_frame_test.cpp
+        test/src/scroll_pane/scroll_pane_test.cpp
         test/src/solid_frame/solid_frame_json_test.cpp
         test/src/solid_frame/solid_frame_test.cpp
         test/src/status_bar/status_bar_test.cpp

--- a/include/munin/edit.hpp
+++ b/include/munin/edit.hpp
@@ -35,6 +35,13 @@ public:
     
 private:
     //* =====================================================================
+    /// \brief Called by set_size().  Derived classes must override this
+    /// function in order to set the size of the component in a custom
+    /// manner.
+    //* =====================================================================
+    void do_set_size(terminalpp::extent const &size) override;
+
+    //* =====================================================================
     /// \brief Called by get_preferred_size().  Derived classes must override
     /// this function in order to get the size of the component in a custom
     /// manner.

--- a/include/munin/frame.hpp
+++ b/include/munin/frame.hpp
@@ -56,6 +56,30 @@ public:
 
 protected:    
     //* =====================================================================
+    /// \brief Override this to describe how to highlight the frame on
+    /// focus.  For example, if there are other sub-components that will
+    /// need to listen to the focus of the inner component.
+    //* =====================================================================
+    virtual void do_highlight_on_focus(
+        std::shared_ptr<component> const &inner_component);
+
+    //* =====================================================================
+    /// \brief Override this to set the lowlight attribute in a custom
+    /// manner.  For example, if there are other sub-components that will
+    /// use the same attribute.
+    //* =====================================================================
+    virtual void do_set_lowlight_attribute(
+        terminalpp::attribute const &lowlight_attribute);
+
+    //* =====================================================================
+    /// \brief Override this to set the highlight attribute in a custom
+    /// manner.  For example, if there are other sub-components that will
+    /// use the same attribute.
+    //* =====================================================================
+    virtual void do_set_highlight_attribute(
+        terminalpp::attribute const &highlight_attribute);
+
+    //* =====================================================================
     /// \brief Returns true if it is allowed for the component to receive
     /// focus, false otherwise.  This is used by the focus functions of
     /// basic_component.  By default, a component may receive focus at all

--- a/include/munin/scroll_frame.hpp
+++ b/include/munin/scroll_frame.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "munin/frame.hpp"
+#include "munin/viewport.hpp"
 #include <memory>
 
 namespace munin {
@@ -10,6 +11,16 @@ namespace munin {
 class MUNIN_EXPORT scroll_frame : public frame
 {
 public:
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    scroll_frame();
+
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    ~scroll_frame() override;
+
     //* =====================================================================
     /// \brief returns the height of the north border.
     //* =====================================================================
@@ -37,6 +48,10 @@ protected:
     /// callbacks so that the frame can be redrawn with this new focus.
     //* =====================================================================
     void do_inner_focus_changed() override;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
 };
 
 //* =========================================================================

--- a/include/munin/scroll_frame.hpp
+++ b/include/munin/scroll_frame.hpp
@@ -22,6 +22,20 @@ public:
     ~scroll_frame() override;
 
     //* =====================================================================
+    /// \brief Sets the horizontal slider position
+    //* =====================================================================
+    void set_horizontal_slider_position(
+        terminalpp::coordinate_type x_position,
+        terminalpp::coordinate_type width);
+
+    //* =====================================================================
+    /// \brief Sets the vertical slider position
+    //* =====================================================================
+    void set_vertical_slider_position(
+        terminalpp::coordinate_type y_position,
+        terminalpp::coordinate_type height);
+
+    //* =====================================================================
     /// \brief returns the height of the north border.
     //* =====================================================================
     terminalpp::coordinate_type north_border_height() const override;

--- a/include/munin/scroll_frame.hpp
+++ b/include/munin/scroll_frame.hpp
@@ -57,6 +57,30 @@ public:
 
 protected:
     //* =====================================================================
+    /// \brief Override this to describe how to highlight the frame on
+    /// focus.  For example, if there are other sub-components that will
+    /// need to listen to the focus of the inner component.
+    //* =====================================================================
+    void do_highlight_on_focus(
+        std::shared_ptr<component> const &inner_component) override;
+
+    //* =====================================================================
+    /// \brief Override this to set the lowlight attribute in a custom
+    /// manner.  For example, if there are other sub-components that will
+    /// use the same attribute.
+    //* =====================================================================
+    void do_set_lowlight_attribute(
+        terminalpp::attribute const &lowlight_attribute) override;
+
+    //* =====================================================================
+    /// \brief Override this to set the highlight attribute in a custom
+    /// manner.  For example, if there are other sub-components that will
+    /// use the same attribute.
+    //* =====================================================================
+    void do_set_highlight_attribute(
+        terminalpp::attribute const &highlight_attribute) override;
+
+    //* =====================================================================
     /// \brief Called when the focus of the associated component has changed
     /// Derived classes must override this to provide appropriate redraw
     /// callbacks so that the frame can be redrawn with this new focus.

--- a/include/munin/scroll_frame.hpp
+++ b/include/munin/scroll_frame.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include "munin/frame.hpp"
+#include <memory>
+
+namespace munin {
+
+//* =========================================================================
+/// \brief A class that frames a viewport using scrollbars.
+//* =========================================================================
+class MUNIN_EXPORT scroll_frame : public frame
+{
+public:
+    //* =====================================================================
+    /// \brief returns the height of the north border.
+    //* =====================================================================
+    terminalpp::coordinate_type north_border_height() const override;
+
+    //* =====================================================================
+    /// \brief returns the height of the south border.
+    //* =====================================================================
+    terminalpp::coordinate_type south_border_height() const override;
+    
+    //* =====================================================================
+    /// \brief returns the width of the west border.
+    //* =====================================================================
+    terminalpp::coordinate_type west_border_width() const override;
+    
+    //* =====================================================================
+    /// \brief returns the width of the east border.
+    //* =====================================================================
+    terminalpp::coordinate_type east_border_width() const override;
+
+protected:
+    //* =====================================================================
+    /// \brief Called when the focus of the associated component has changed
+    /// Derived classes must override this to provide appropriate redraw
+    /// callbacks so that the frame can be redrawn with this new focus.
+    //* =====================================================================
+    void do_inner_focus_changed() override;
+};
+
+//* =========================================================================
+/// \brief Returns a newly-created scroll frame.
+//* =========================================================================
+MUNIN_EXPORT
+std::shared_ptr<scroll_frame> make_scroll_frame();
+
+}

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -4,13 +4,34 @@
 
 namespace munin {
 
+//* =========================================================================
+/// \brief A component that wraps another component in a frame,
+/// and implements scroll bars that track the visible section of the 
+/// component.
+//* =========================================================================
 class MUNIN_EXPORT scroll_pane : public framed_component
 {
 public:
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
     scroll_pane(std::shared_ptr<component> const &inner_component);
+
+    //* =====================================================================
+    /// \brief Destructor
+    //* =====================================================================
     ~scroll_pane();
 
+    //* =====================================================================
+    /// \brief Sets the attribute of the elements when the inner component
+    /// has focus.
+    //* =====================================================================
     void set_highlight_attribute(terminalpp::attribute const &attr);
+
+    //* =====================================================================
+    /// \brief Sets the attribute of the elements when the inner component
+    /// does not have focus.
+    //* =====================================================================
     void set_lowlight_attribute(terminalpp::attribute const &attr);
 
 private:
@@ -22,7 +43,6 @@ private:
     struct impl;
     std::unique_ptr<impl> pimpl_;
 };
-
 
 MUNIN_EXPORT
 std::shared_ptr<scroll_pane> make_scroll_pane(std::shared_ptr<component> const &inner_component);

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -8,6 +8,16 @@ class MUNIN_EXPORT scroll_pane : public framed_component
 {
 public:
     scroll_pane(std::shared_ptr<component> const &inner_component);
+    ~scroll_pane();
+
+private:
+    scroll_pane(
+        std::shared_ptr<component> const &frame,
+        std::shared_ptr<component> const &viewport,
+        std::shared_ptr<component> const &inner_component);
+
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
 };
 
 

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -11,6 +11,7 @@ public:
     ~scroll_pane();
 
     void set_highlight_attribute(terminalpp::attribute const &attr);
+    void set_lowlight_attribute(terminalpp::attribute const &attr);
 
 private:
     scroll_pane(

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -10,6 +10,8 @@ public:
     scroll_pane(std::shared_ptr<component> const &inner_component);
     ~scroll_pane();
 
+    void set_highlight_attribute(terminalpp::attribute const &attr);
+
 private:
     scroll_pane(
         std::shared_ptr<component> const &frame,

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -15,12 +15,12 @@ public:
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    scroll_pane(std::shared_ptr<component> const &inner_component);
+    explicit scroll_pane(std::shared_ptr<component> const &inner_component);
 
     //* =====================================================================
     /// \brief Destructor
     //* =====================================================================
-    ~scroll_pane();
+    ~scroll_pane() override;
 
     //* =====================================================================
     /// \brief Sets the attribute of the elements when the inner component

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "munin/framed_component.hpp"
+#include <memory>
+
+namespace munin {
+
+class MUNIN_EXPORT scroll_pane : public framed_component
+{
+public:
+    scroll_pane(std::shared_ptr<component> const &inner_component);
+};
+
+
+MUNIN_EXPORT
+std::shared_ptr<scroll_pane> make_scroll_pane(std::shared_ptr<component> const &inner_component);
+
+}

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -21,6 +21,25 @@ public:
     //* =====================================================================
     ~viewport() override;
     
+    //* =====================================================================
+    /// \brief Returns the anchor bounds of the viewport.
+    ///
+    /// The anchor bounds are defined as the bounds in which the top-left
+    /// corner of the viewport could possibly be in relation to the tracked
+    /// component.  For example, if the underlying component is (20,20), and
+    /// the viewport was (5,5), then the bounds could by from (0,0)->(15,15)
+    /// before running out of space.  In the rectangle returned, the
+    /// origin refers to the actual anchor position, and the size refers
+    /// to the extent of the bounds as described above.
+    //* =====================================================================
+    terminalpp::rectangle get_anchor_bounds() const;
+
+    //* =====================================================================
+    /// \brief Connect to this signal in order to receive notifications when
+    /// the anchor bounds have changed.
+    //* =====================================================================
+    boost::signals2::signal<void ()> on_anchor_bounds_changed;
+
 private:
     //* =====================================================================
     /// \brief Called by set_size().  Derived classes must override this

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -29,6 +29,33 @@ frame::frame()
 void frame::highlight_on_focus(
     std::shared_ptr<component> const &inner_component)
 {
+    do_highlight_on_focus(inner_component);
+}
+
+// ==========================================================================
+// SET_LOWLIGHT_ATTRIBUTE
+// ==========================================================================
+void frame::set_lowlight_attribute(
+    terminalpp::attribute const &lowlight_attribute)
+{
+    do_set_lowlight_attribute(lowlight_attribute);
+}
+
+// ==========================================================================
+// SET_HIGHLIGHT_ATTRIBUTE
+// ==========================================================================
+void frame::set_highlight_attribute(
+    terminalpp::attribute const &highlight_attribute)
+{
+    do_set_highlight_attribute(highlight_attribute);
+}
+
+// ==========================================================================
+// DO_HIGHLIGHT_ON_FOCUS
+// ==========================================================================
+void frame::do_highlight_on_focus(
+    std::shared_ptr<component> const &inner_component)
+{
     inner_component_ = inner_component;
 
     auto evaluate_focus = 
@@ -48,9 +75,9 @@ void frame::highlight_on_focus(
 }
 
 // ==========================================================================
-// HIGHLIGHT_ON_FOCUS
+// DO_SET_LOWLIGHT_ATTRIBUTE
 // ==========================================================================
-void frame::set_lowlight_attribute(
+void frame::do_set_lowlight_attribute(
     terminalpp::attribute const &lowlight_attribute)
 {
     lowlight_attribute_ = lowlight_attribute;
@@ -58,9 +85,9 @@ void frame::set_lowlight_attribute(
 }
 
 // ==========================================================================
-// HIGHLIGHT_ON_FOCUS
+// DO_SET_HIGHLIGHT_ATTRIBUTE
 // ==========================================================================
-void frame::set_highlight_attribute(
+void frame::do_set_highlight_attribute(
     terminalpp::attribute const &highlight_attribute)
 {
     highlight_attribute_ = highlight_attribute;
@@ -68,7 +95,7 @@ void frame::set_highlight_attribute(
 }
 
 // ==========================================================================
-// HIGHLIGHT_ON_FOCUS
+// GET_FOCUS_ATTRIBUTE
 // ==========================================================================
 terminalpp::attribute frame::get_focus_attribute() const
 {

--- a/src/horizontal_scrollbar.cpp
+++ b/src/horizontal_scrollbar.cpp
@@ -61,7 +61,7 @@ struct horizontal_scrollbar::impl
             auto const &slider_is_in_rightmost_position =
                 [=]
                 {
-                    return viewport_x_position == viewport_basis_width - 1;
+                    return viewport_x_position == viewport_basis_width;
                 };
 
             auto const &interpolate_slider_position =

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -57,7 +57,7 @@ scroll_frame::~scroll_frame() = default;
 // ==========================================================================
 terminalpp::coordinate_type scroll_frame::north_border_height() const
 {
-    return 0;
+    return 1;
 }
 
 // ==========================================================================
@@ -65,7 +65,7 @@ terminalpp::coordinate_type scroll_frame::north_border_height() const
 // ==========================================================================
 terminalpp::coordinate_type scroll_frame::south_border_height() const
 {
-    return 0;
+    return 1;
 }
 
 // ==========================================================================
@@ -73,7 +73,7 @@ terminalpp::coordinate_type scroll_frame::south_border_height() const
 // ==========================================================================
 terminalpp::coordinate_type scroll_frame::west_border_width() const
 {
-    return 0;
+    return 1;
 }
 
 // ==========================================================================
@@ -81,7 +81,7 @@ terminalpp::coordinate_type scroll_frame::west_border_width() const
 // ==========================================================================
 terminalpp::coordinate_type scroll_frame::east_border_width() const
 {
-    return 0;
+    return 1;
 }
 
 // ==========================================================================

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -7,6 +7,18 @@
 #include <boost/make_unique.hpp>
 namespace munin {
 
+namespace {
+
+constexpr terminalpp::attribute default_lowlight_attribute = {};
+
+constexpr terminalpp::attribute default_highlight_attribute = {
+    terminalpp::graphics::colour::cyan,
+    {},
+    terminalpp::graphics::intensity::bold
+};
+
+}
+
 // ==========================================================================
 // SCROLL_FRAME IMPLEMENTATION STRUCTURE
 // ==========================================================================
@@ -24,7 +36,15 @@ scroll_frame::scroll_frame()
   : pimpl_(boost::make_unique<impl>())
 {
     pimpl_->horizontal_scrollbar_ = make_horizontal_scrollbar();
+    pimpl_->horizontal_scrollbar_->set_lowlight_attribute(
+        default_lowlight_attribute);
+    pimpl_->horizontal_scrollbar_->set_highlight_attribute(
+        default_highlight_attribute);
     pimpl_->vertical_scrollbar_ = make_vertical_scrollbar();
+    pimpl_->vertical_scrollbar_->set_lowlight_attribute(
+        default_lowlight_attribute);
+    pimpl_->vertical_scrollbar_->set_highlight_attribute(
+        default_highlight_attribute);
 
     auto &attr = pimpl_->current_attribute_;
 

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -1,6 +1,56 @@
 #include "munin/scroll_frame.hpp"
-
+#include "munin/detail/adaptive_fill.hpp"
+#include "munin/compass_layout.hpp"
+#include "munin/horizontal_scrollbar.hpp"
+#include "munin/vertical_scrollbar.hpp"
+#include "munin/view.hpp"
+#include <boost/make_unique.hpp>
 namespace munin {
+
+// ==========================================================================
+// SCROLL_FRAME IMPLEMENTATION STRUCTURE
+// ==========================================================================
+struct scroll_frame::impl
+{
+    terminalpp::attribute current_attribute;
+};
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+scroll_frame::scroll_frame()
+  : pimpl_(boost::make_unique<impl>())
+{
+    auto &attr = pimpl_->current_attribute;
+
+    auto north_beam = view(
+        make_compass_layout(),
+        detail::make_top_left_corner_fill(attr), compass_layout::heading::west,
+        detail::make_horizontal_beam_fill(attr), compass_layout::heading::centre,
+        detail::make_top_right_corner_fill(attr),  compass_layout::heading::east);
+
+    auto south_beam = view(
+        make_compass_layout(),
+        detail::make_bottom_left_corner_fill(attr), compass_layout::heading::west,
+        make_horizontal_scrollbar(), compass_layout::heading::centre,
+        detail::make_bottom_right_corner_fill(attr), compass_layout::heading::east);
+
+
+    auto west_beam = detail::make_vertical_beam_fill(attr);
+    auto east_beam = make_vertical_scrollbar();
+
+    set_layout(make_compass_layout());
+
+    add_component(north_beam, compass_layout::heading::north);
+    add_component(south_beam, compass_layout::heading::south);
+    add_component(west_beam, compass_layout::heading::west);
+    add_component(east_beam, compass_layout::heading::east);
+}
+
+// ==========================================================================
+// DESTRUCTOR
+// ==========================================================================
+scroll_frame::~scroll_frame() = default;
 
 // ==========================================================================
 // NORTH_BORDER_HEIGHT

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -110,10 +110,44 @@ terminalpp::coordinate_type scroll_frame::east_border_width() const
 }
 
 // ==========================================================================
+// DO_HIGHLIGHT_ON_FOCUS
+// ==========================================================================
+void scroll_frame::do_highlight_on_focus(
+    std::shared_ptr<component> const &inner_component)
+{
+    pimpl_->horizontal_scrollbar_->highlight_on_focus(inner_component);
+    pimpl_->vertical_scrollbar_->highlight_on_focus(inner_component);
+    frame::do_highlight_on_focus(inner_component);
+}
+
+// ==========================================================================
+// DO_SET_LOWLIGHT_ATTRIBUTE
+// ==========================================================================
+void scroll_frame::do_set_lowlight_attribute(
+    terminalpp::attribute const &lowlight_attribute)
+{
+    pimpl_->horizontal_scrollbar_->set_lowlight_attribute(lowlight_attribute);
+    pimpl_->vertical_scrollbar_->set_lowlight_attribute(lowlight_attribute);
+    frame::do_set_lowlight_attribute(lowlight_attribute);
+}
+
+// ==========================================================================
+// DO_SET_HIGHLIGHT_ATTRIBUTE
+// ==========================================================================
+void scroll_frame::do_set_highlight_attribute(
+    terminalpp::attribute const &highlight_attribute)
+{
+    pimpl_->horizontal_scrollbar_->set_highlight_attribute(highlight_attribute);
+    pimpl_->vertical_scrollbar_->set_highlight_attribute(highlight_attribute);
+    frame::do_set_highlight_attribute(highlight_attribute);
+}
+
+// ==========================================================================
 // DO_INNER_FOCUS_CHANGE
 // ==========================================================================
 void scroll_frame::do_inner_focus_changed()
 {
+    pimpl_->current_attribute_ = get_focus_attribute();
 }
 
 // ==========================================================================

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -1,0 +1,52 @@
+#include "munin/scroll_frame.hpp"
+
+namespace munin {
+
+// ==========================================================================
+// NORTH_BORDER_HEIGHT
+// ==========================================================================
+terminalpp::coordinate_type scroll_frame::north_border_height() const
+{
+    return 0;
+}
+
+// ==========================================================================
+// SOUTH_BORDER_HEIGHT
+// ==========================================================================
+terminalpp::coordinate_type scroll_frame::south_border_height() const
+{
+    return 0;
+}
+
+// ==========================================================================
+// WEST_BORDER_WIDTH
+// ==========================================================================
+terminalpp::coordinate_type scroll_frame::west_border_width() const
+{
+    return 0;
+}
+
+// ==========================================================================
+// EAST_BORDER_WIDTH
+// ==========================================================================
+terminalpp::coordinate_type scroll_frame::east_border_width() const
+{
+    return 0;
+}
+
+// ==========================================================================
+// DO_INNER_FOCUS_CHANGE
+// ==========================================================================
+void scroll_frame::do_inner_focus_changed()
+{
+}
+
+// ==========================================================================
+// MAKE_SOLID_FRAME
+// ==========================================================================
+std::shared_ptr<scroll_frame> make_scroll_frame()
+{
+    return std::make_shared<scroll_frame>();
+}
+
+}

--- a/src/scroll_frame.cpp
+++ b/src/scroll_frame.cpp
@@ -12,7 +12,9 @@ namespace munin {
 // ==========================================================================
 struct scroll_frame::impl
 {
-    terminalpp::attribute current_attribute;
+    terminalpp::attribute current_attribute_;
+    std::shared_ptr<horizontal_scrollbar> horizontal_scrollbar_;
+    std::shared_ptr<vertical_scrollbar> vertical_scrollbar_;
 };
 
 // ==========================================================================
@@ -21,7 +23,10 @@ struct scroll_frame::impl
 scroll_frame::scroll_frame()
   : pimpl_(boost::make_unique<impl>())
 {
-    auto &attr = pimpl_->current_attribute;
+    pimpl_->horizontal_scrollbar_ = make_horizontal_scrollbar();
+    pimpl_->vertical_scrollbar_ = make_vertical_scrollbar();
+
+    auto &attr = pimpl_->current_attribute_;
 
     auto north_beam = view(
         make_compass_layout(),
@@ -32,12 +37,12 @@ scroll_frame::scroll_frame()
     auto south_beam = view(
         make_compass_layout(),
         detail::make_bottom_left_corner_fill(attr), compass_layout::heading::west,
-        make_horizontal_scrollbar(), compass_layout::heading::centre,
+        pimpl_->horizontal_scrollbar_, compass_layout::heading::centre,
         detail::make_bottom_right_corner_fill(attr), compass_layout::heading::east);
 
 
     auto west_beam = detail::make_vertical_beam_fill(attr);
-    auto east_beam = make_vertical_scrollbar();
+    auto east_beam = pimpl_->vertical_scrollbar_;
 
     set_layout(make_compass_layout());
 
@@ -51,6 +56,26 @@ scroll_frame::scroll_frame()
 // DESTRUCTOR
 // ==========================================================================
 scroll_frame::~scroll_frame() = default;
+
+// ==========================================================================
+// SET_HORIZONTAL_SLIDER_POSITION
+// ==========================================================================
+void scroll_frame::set_horizontal_slider_position(
+    terminalpp::coordinate_type x_position,
+    terminalpp::coordinate_type width)
+{
+    pimpl_->horizontal_scrollbar_->set_slider_position(x_position, width);
+}
+
+// ==========================================================================
+// SET_VERTICAL_SLIDER_POSITION
+// ==========================================================================
+void scroll_frame::set_vertical_slider_position(
+    terminalpp::coordinate_type y_position,
+    terminalpp::coordinate_type height)
+{
+    pimpl_->vertical_scrollbar_->set_slider_position(y_position, height);
+}
 
 // ==========================================================================
 // NORTH_BORDER_HEIGHT

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -1,0 +1,24 @@
+#include "munin/scroll_pane.hpp"
+#include "munin/solid_frame.hpp"
+
+namespace munin {
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+scroll_pane::scroll_pane(std::shared_ptr<component> const &inner_component)
+  : framed_component(make_solid_frame(), inner_component)
+{
+
+}
+
+// ==========================================================================
+// MAKE_SCROLL_PANE
+// ==========================================================================
+std::shared_ptr<scroll_pane> make_scroll_pane(
+    std::shared_ptr<component> const &inner_component)
+{
+    return std::make_shared<scroll_pane>(inner_component);
+}
+
+}

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -63,6 +63,14 @@ scroll_pane::scroll_pane(
 scroll_pane::~scroll_pane() = default;
 
 // ==========================================================================
+// SET_HIGHLIGHT_ATTRIBUTE
+// ==========================================================================
+void scroll_pane::set_highlight_attribute(terminalpp::attribute const &attr)
+{
+    pimpl_->frame_->set_highlight_attribute(attr);
+}
+
+// ==========================================================================
 // MAKE_SCROLL_PANE
 // ==========================================================================
 std::shared_ptr<scroll_pane> make_scroll_pane(

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -1,16 +1,66 @@
 #include "munin/scroll_pane.hpp"
-#include "munin/solid_frame.hpp"
+#include "munin/scroll_frame.hpp"
+#include "munin/viewport.hpp"
+#include <boost/make_unique.hpp>
 
 namespace munin {
+
+// ==========================================================================
+// SCROLL_PANE::IMPLEMENTATION STRUCTURE
+// ==========================================================================
+struct scroll_pane::impl
+{
+    // ======================================================================
+    // UPDATE_ANCHOR_BOUNDS
+    // ======================================================================
+    void update_anchor_bounds()
+    {
+        auto const anchor_bounds = viewport_->get_anchor_bounds();
+        frame_->set_horizontal_slider_position(
+            anchor_bounds.origin_.x_, anchor_bounds.size_.width_);
+        frame_->set_vertical_slider_position(
+            anchor_bounds.origin_.y_, anchor_bounds.size_.height_);
+    }
+
+    std::shared_ptr<scroll_frame> frame_;
+    std::shared_ptr<viewport> viewport_;
+};
 
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
 scroll_pane::scroll_pane(std::shared_ptr<component> const &inner_component)
-  : framed_component(make_solid_frame(), inner_component)
+  : scroll_pane(
+      make_scroll_frame(), 
+      make_viewport(inner_component),
+      inner_component)
 {
-
 }
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+scroll_pane::scroll_pane(
+    std::shared_ptr<component> const &inner_frame,
+    std::shared_ptr<component> const &inner_viewport,
+    std::shared_ptr<component> const &inner_component)
+  : framed_component(
+      std::static_pointer_cast<frame>(inner_frame),
+      std::static_pointer_cast<viewport>(inner_viewport)),
+    pimpl_(boost::make_unique<impl>())
+{
+    pimpl_->frame_ = std::static_pointer_cast<scroll_frame>(inner_frame);
+    pimpl_->viewport_ = std::static_pointer_cast<viewport>(inner_viewport);
+
+    pimpl_->viewport_->on_anchor_bounds_changed.connect(
+        [this] { pimpl_->update_anchor_bounds(); });
+    pimpl_->update_anchor_bounds();
+}
+
+// ==========================================================================
+// DESTRUCTOR
+// ==========================================================================
+scroll_pane::~scroll_pane() = default;
 
 // ==========================================================================
 // MAKE_SCROLL_PANE

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -71,6 +71,14 @@ void scroll_pane::set_highlight_attribute(terminalpp::attribute const &attr)
 }
 
 // ==========================================================================
+// SET_LOWLIGHT_ATTRIBUTE
+// ==========================================================================
+void scroll_pane::set_lowlight_attribute(terminalpp::attribute const &attr)
+{
+    pimpl_->frame_->set_lowlight_attribute(attr);
+}
+
+// ==========================================================================
 // MAKE_SCROLL_PANE
 // ==========================================================================
 std::shared_ptr<scroll_pane> make_scroll_pane(

--- a/src/vertical_scrollbar.cpp
+++ b/src/vertical_scrollbar.cpp
@@ -61,7 +61,7 @@ struct vertical_scrollbar::impl
             auto const &slider_is_in_bottommost_position =
                 [=]
                 {
-                    return viewport_y_position == viewport_basis_height - 1;
+                    return viewport_y_position == viewport_basis_height;
                 };
 
             auto const &interpolate_slider_position =

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -271,6 +271,8 @@ private:
     void on_tracked_component_preferred_size_changed()
     {
         update_tracked_component_size();
+        update_anchor_position();
+        update_cursor_position();
         self_.on_preferred_size_changed();
     }
     

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -230,6 +230,7 @@ struct viewport::impl
 
         if (old_anchor_bounds != anchor_bounds_)
         {
+            std::cout << "anchor bounds changed: " << anchor_bounds_ << std::endl;
             self_.on_anchor_bounds_changed();
             self_.on_redraw({terminalpp::rectangle{{}, self_.get_size()}});
         }

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -38,6 +38,14 @@ struct viewport::impl
     }
     
     // ======================================================================
+    // GET_ANCHOR_BOUNDS
+    // ======================================================================
+    auto get_anchor_bounds() const
+    {
+        return anchor_bounds_;
+    }
+ 
+    // ======================================================================
     // GET_PREFERRED_SIZE
     // ======================================================================
     auto get_preferred_size() const
@@ -107,7 +115,7 @@ struct viewport::impl
     void draw(render_surface& surface, terminalpp::rectangle const &region)
     {
         auto const offset_region = terminalpp::rectangle{
-            region.origin_ + anchor_position_,
+            region.origin_ + anchor_bounds_.origin_,
             region.size_
         };
 
@@ -120,8 +128,8 @@ struct viewport::impl
         // viewport.  By offsetting by (-2, -2) (the negative of the anchor
         // position), the tracked component draws in the correct space.
         surface.offset_by({
-            -anchor_position_.x_,
-            -anchor_position_.y_
+            -anchor_bounds_.origin_.x_,
+            -anchor_bounds_.origin_.y_
         });
 
         // Ensure that the offset is unapplied before exit of this
@@ -129,8 +137,8 @@ struct viewport::impl
         BOOST_SCOPE_EXIT_ALL(&surface, this)
         {
             surface.offset_by({
-                anchor_position_.x_,
-                anchor_position_.y_
+                anchor_bounds_.origin_.x_,
+                anchor_bounds_.origin_.y_
             });
         };
 
@@ -149,7 +157,7 @@ struct viewport::impl
         {
             auto const translated_event = terminalpp::mouse::event {
                 mouse_event->action_,
-                mouse_event->position_ + anchor_position_
+                mouse_event->position_ + anchor_bounds_.origin_
             };
 
             return tracked_component_->event(translated_event);
@@ -182,7 +190,7 @@ struct viewport::impl
     void update_anchor_position()
     {
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
-        auto const old_anchor_position = anchor_position_;
+        auto const old_anchor_bounds = anchor_bounds_;
         auto const tracked_component_size = tracked_component_->get_size();
         auto const viewport_size = self_.get_size();
 
@@ -196,32 +204,33 @@ struct viewport::impl
         // If the viewport has changed its size, look to see if the tracked
         // component is contained entirely in the viewport.  If not, then
         // adjust the anchor appropriately.
-        auto const max_allowed_anchor_position = terminalpp::point {
+        anchor_bounds_.size_ = {
             tracked_component_size.width_ - viewport_size.width_,
             tracked_component_size.height_ - viewport_size.height_
         };
 
-        anchor_position_ = {
-            std::min(anchor_position_.x_, max_allowed_anchor_position.x_),
-            std::min(anchor_position_.y_, max_allowed_anchor_position.y_)
+        anchor_bounds_.origin_ = {
+            std::min(anchor_bounds_.origin_.x_, anchor_bounds_.size_.width_),
+            std::min(anchor_bounds_.origin_.y_, anchor_bounds_.size_.height_)
         };
 
         // Check to see if the tracked cursor has scrolled off any of the
         // edges of the viewport.  If so, then the anchor position must change 
         // just enough to keep the cursor within the visual area.
-        anchor_position_ = {
+        anchor_bounds_.origin_ = {
             boost::algorithm::clamp(
-                anchor_position_.x_, 
+                anchor_bounds_.origin_.x_, 
                 tracked_cursor_position.x_ - viewport_size.width_ + 1, 
                 tracked_cursor_position.x_),
             boost::algorithm::clamp(
-                anchor_position_.y_,
+                anchor_bounds_.origin_.y_,
                 tracked_cursor_position.y_ - viewport_size.height_ + 1, 
                 tracked_cursor_position.y_)
         };
 
-        if (old_anchor_position != anchor_position_)
+        if (old_anchor_bounds != anchor_bounds_)
         {
+            self_.on_anchor_bounds_changed();
             self_.on_redraw({terminalpp::rectangle{{}, self_.get_size()}});
         }
     }
@@ -235,8 +244,8 @@ struct viewport::impl
         auto const tracked_cursor_position = tracked_component_->get_cursor_position();
 
         cursor_position_ = {
-            tracked_cursor_position.x_ - anchor_position_.x_,
-            tracked_cursor_position.y_ - anchor_position_.y_
+            tracked_cursor_position.x_ - anchor_bounds_.origin_.x_,
+            tracked_cursor_position.y_ - anchor_bounds_.origin_.y_
         };
 
         if (old_cursor_position != cursor_position_)
@@ -277,8 +286,8 @@ private:
             {
                 return terminalpp::rectangle{
                     { 
-                        region.origin_.x_ - anchor_position_.x_,
-                        region.origin_.y_ - anchor_position_.y_
+                        region.origin_.x_ - anchor_bounds_.origin_.x_,
+                        region.origin_.y_ - anchor_bounds_.origin_.y_
                     },
                     region.size_
                 };
@@ -320,7 +329,7 @@ private:
 
     viewport &self_;
     std::shared_ptr<component> tracked_component_;
-    terminalpp::point          anchor_position_;
+    terminalpp::rectangle      anchor_bounds_;
     terminalpp::point          cursor_position_;
 };
 
@@ -336,6 +345,14 @@ viewport::viewport(std::shared_ptr<component> tracked_component)
 // DESTRUCTOR
 // ==========================================================================
 viewport::~viewport() = default;
+
+// ==========================================================================
+// GET_ANCHOR_BOUNDS
+// ==========================================================================
+terminalpp::rectangle viewport::get_anchor_bounds() const
+{
+    return pimpl_->get_anchor_bounds();
+}
 
 // ==========================================================================
 // DO_SET_SIZE

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -230,7 +230,6 @@ struct viewport::impl
 
         if (old_anchor_bounds != anchor_bounds_)
         {
-            std::cout << "anchor bounds changed: " << anchor_bounds_ << std::endl;
             self_.on_anchor_bounds_changed();
             self_.on_redraw({terminalpp::rectangle{{}, self_.get_size()}});
         }

--- a/test/src/edit/edit_with_content_test.cpp
+++ b/test/src/edit/edit_with_content_test.cpp
@@ -123,7 +123,7 @@ INSTANTIATE_TEST_SUITE_P(
         keypress_data{ "tes", {0, 0}, terminalpp::vk::uppercase_t, "Ttes", "Ttes", {1, 0} },
         keypress_data{ "tes", {1, 0}, terminalpp::vk::uppercase_t, "tTes", "tTes", {2, 0} },
         keypress_data{ "tes", {2, 0}, terminalpp::vk::uppercase_t, "teTs", "teTs", {3, 0} },
-        keypress_data{ "tes", {3, 0}, terminalpp::vk::uppercase_t, "tesT", "tesT", {4, 0} },
+        keypress_data{ "tes", {3, 0}, terminalpp::vk::uppercase_t, "tesT", "tesT", {3, 0} },
 
         // Cursor movement.
         keypress_data{ "t", {1, 0}, terminalpp::vk::cursor_right, "t", "t", {1, 0} },
@@ -142,11 +142,11 @@ INSTANTIATE_TEST_SUITE_P(
 
         keypress_data{ "t",    {0, 0}, terminalpp::vk::end, "t",    "t",    {1, 0} },
         keypress_data{ "t",    {1, 0}, terminalpp::vk::end, "t",    "t",    {1, 0} },
-        keypress_data{ "test", {0, 0}, terminalpp::vk::end, "test", "test", {4, 0} },
-        keypress_data{ "test", {1, 0}, terminalpp::vk::end, "test", "test", {4, 0} },
-        keypress_data{ "test", {2, 0}, terminalpp::vk::end, "test", "test", {4, 0} },
-        keypress_data{ "test", {3, 0}, terminalpp::vk::end, "test", "test", {4, 0} },
-        keypress_data{ "test", {4, 0}, terminalpp::vk::end, "test", "test", {4, 0} },
+        keypress_data{ "test", {0, 0}, terminalpp::vk::end, "test", "test", {3, 0} },
+        keypress_data{ "test", {1, 0}, terminalpp::vk::end, "test", "test", {3, 0} },
+        keypress_data{ "test", {2, 0}, terminalpp::vk::end, "test", "test", {3, 0} },
+        keypress_data{ "test", {3, 0}, terminalpp::vk::end, "test", "test", {3, 0} },
+        keypress_data{ "test", {4, 0}, terminalpp::vk::end, "test", "test", {3, 0} },
 
         // Test writing off the end of the viewable portion of the edit.
         // In all cases, this should continue exactly as it did, but should
@@ -157,8 +157,8 @@ INSTANTIATE_TEST_SUITE_P(
         keypress_data{ "test", {0, 0}, terminalpp::vk::lowercase_z, "ztes", "ztest", {1, 0} },
         keypress_data{ "test", {1, 0}, terminalpp::vk::lowercase_z, "tzes", "tzest", {2, 0} },
         keypress_data{ "test", {2, 0}, terminalpp::vk::lowercase_z, "tezs", "tezst", {3, 0} },
-        keypress_data{ "test", {3, 0}, terminalpp::vk::lowercase_z, "tesz", "teszt", {4, 0} },
-        keypress_data{ "test", {4, 0}, terminalpp::vk::lowercase_z, "test", "testz", {5, 0} },
+        keypress_data{ "test", {3, 0}, terminalpp::vk::lowercase_z, "tesz", "teszt", {3, 0} },
+        keypress_data{ "test", {4, 0}, terminalpp::vk::lowercase_z, "test", "testz", {3, 0} },
         
         // Pressing the backspace or DEL keys result in deleting the character
         // to the left of the cursor and retreating the cursor one step.

--- a/test/src/scroll_frame/scroll_frame_test.cpp
+++ b/test/src/scroll_frame/scroll_frame_test.cpp
@@ -1,0 +1,10 @@
+#include <munin/scroll_frame.hpp>
+#include <gtest/gtest.h>
+
+TEST(a_scroll_frame, is_a_frame)
+{
+    std::shared_ptr<munin::scroll_frame> scroll_frame = 
+        munin::make_scroll_frame();
+
+    std::shared_ptr<munin::frame> frame = scroll_frame;
+}

--- a/test/src/scroll_frame/scroll_frame_test.cpp
+++ b/test/src/scroll_frame/scroll_frame_test.cpp
@@ -1,10 +1,61 @@
+#include "mock/component.hpp"
 #include <munin/scroll_frame.hpp>
+#include <munin/detail/unicode_glyphs.hpp>
+#include <munin/render_surface.hpp>
+#include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
 
-TEST(a_scroll_frame, is_a_frame)
-{
-    std::shared_ptr<munin::scroll_frame> scroll_frame = 
-        munin::make_scroll_frame();
+using testing::Return;
 
-    std::shared_ptr<munin::frame> frame = scroll_frame;
+namespace {
+
+class a_new_scroll_frame : public testing::Test
+{
+protected:
+    std::shared_ptr<munin::scroll_frame> scroll_frame_ {
+        munin::make_scroll_frame()
+    };
+};
+
+}
+
+TEST_F(a_new_scroll_frame, is_a_frame)
+{
+    std::shared_ptr<munin::frame> frame = scroll_frame_;
+}
+
+TEST_F(a_new_scroll_frame, draws_a_solid_frame)
+{
+    terminalpp::canvas canvas({4, 4});
+    munin::render_surface surface{canvas};
+
+    terminalpp::for_each_in_region(
+        canvas,
+        {{}, canvas.size()},
+        [](terminalpp::element &elem,
+           terminalpp::coordinate_type column,
+           terminalpp::coordinate_type row)
+        {
+            elem = 'X';
+        });
+
+    scroll_frame_->set_size({4, 4});
+    scroll_frame_->draw(surface, {{0, 0}, {4, 4}});
+
+    ASSERT_EQ(munin::detail::single_lined_rounded_top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[1][0]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[2][0]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[0][1]);
+    ASSERT_EQ(terminalpp::element{'X'},                                canvas[1][1]);
+    ASSERT_EQ(terminalpp::element{'X'},                                canvas[2][1]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[3][1]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[0][2]);
+    ASSERT_EQ(terminalpp::element{'X'},                                canvas[1][2]);
+    ASSERT_EQ(terminalpp::element{'X'},                                canvas[2][2]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[3][2]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[1][3]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[2][3]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_bottom_right_corner, canvas[3][3]);
 }

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -142,3 +142,88 @@ TEST_F(a_new_scroll_pane, tracks_the_cursor_in_the_inner_component)
     ASSERT_EQ(munin::detail::single_lined_cross,                       canvas[2][3]);
     ASSERT_EQ(munin::detail::single_lined_rounded_bottom_right_corner, canvas[3][3]);
 }
+
+namespace {
+
+constexpr auto highlight_attribute = terminalpp::attribute{
+    terminalpp::high_colour(5, 4, 1)
+};
+
+constexpr auto highlighted_single_lined_rounded_top_left_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_top_left_corner,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_horizontal_beam = terminalpp::element{
+    munin::detail::single_lined_horizontal_beam,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_cross = terminalpp::element{
+    munin::detail::single_lined_cross,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_rounded_top_right_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_top_right_corner,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_vertical_beam = terminalpp::element{
+    munin::detail::single_lined_vertical_beam,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_rounded_bottom_left_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_bottom_left_corner,
+    highlight_attribute
+};
+
+constexpr auto highlighted_single_lined_rounded_bottom_right_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_bottom_right_corner,
+    highlight_attribute
+};
+
+}
+
+TEST_F(a_new_scroll_pane, highlights_the_whole_frame_when_the_underlying_component_receives_focus)
+{
+    terminalpp::canvas canvas({4, 4});
+    munin::render_surface surface{canvas};
+
+    terminalpp::for_each_in_region(
+        canvas,
+        {{}, canvas.size()},
+        [](terminalpp::element &elem,
+           terminalpp::coordinate_type column,
+           terminalpp::coordinate_type row)
+        {
+            elem = 'X';
+        });
+
+    scroll_pane->set_size({4, 4});
+    scroll_pane->set_highlight_attribute(highlight_attribute);
+    
+    ON_CALL(*inner_component_, do_has_focus())
+        .WillByDefault(Return(true));
+    inner_component_->on_focus_set();
+
+    scroll_pane->draw(surface, {{0, 0}, {4, 4}});
+
+    EXPECT_EQ(highlighted_single_lined_rounded_top_left_corner,     canvas[0][0]);
+    EXPECT_EQ(highlighted_single_lined_horizontal_beam,             canvas[1][0]);
+    EXPECT_EQ(highlighted_single_lined_horizontal_beam,             canvas[2][0]);
+    EXPECT_EQ(highlighted_single_lined_rounded_top_right_corner,    canvas[3][0]);
+    EXPECT_EQ(highlighted_single_lined_vertical_beam,               canvas[0][1]);
+    EXPECT_EQ(terminalpp::element{'0'},                             canvas[1][1]);
+    EXPECT_EQ(terminalpp::element{'1'},                             canvas[2][1]);
+    EXPECT_EQ(highlighted_single_lined_cross,                       canvas[3][1]);
+    EXPECT_EQ(highlighted_single_lined_vertical_beam,               canvas[0][2]);
+    EXPECT_EQ(terminalpp::element{'1'},                             canvas[1][2]);
+    EXPECT_EQ(terminalpp::element{'2'},                             canvas[2][2]);
+    EXPECT_EQ(highlighted_single_lined_vertical_beam,               canvas[3][2]);
+    EXPECT_EQ(highlighted_single_lined_rounded_bottom_left_corner,  canvas[0][3]);
+    EXPECT_EQ(highlighted_single_lined_cross,                       canvas[1][3]);
+    EXPECT_EQ(highlighted_single_lined_horizontal_beam,             canvas[2][3]);
+    EXPECT_EQ(highlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
+}

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -227,3 +227,93 @@ TEST_F(a_new_scroll_pane, highlights_the_whole_frame_when_the_underlying_compone
     EXPECT_EQ(highlighted_single_lined_horizontal_beam,             canvas[2][3]);
     EXPECT_EQ(highlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
 }
+
+namespace {
+
+constexpr auto lowlight_attribute = terminalpp::attribute{
+    terminalpp::high_colour(2, 1, 2)
+};
+
+constexpr auto lowlighted_single_lined_rounded_top_left_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_top_left_corner,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_horizontal_beam = terminalpp::element{
+    munin::detail::single_lined_horizontal_beam,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_cross = terminalpp::element{
+    munin::detail::single_lined_cross,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_rounded_top_right_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_top_right_corner,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_vertical_beam = terminalpp::element{
+    munin::detail::single_lined_vertical_beam,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_rounded_bottom_left_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_bottom_left_corner,
+    lowlight_attribute
+};
+
+constexpr auto lowlighted_single_lined_rounded_bottom_right_corner = terminalpp::element{
+    munin::detail::single_lined_rounded_bottom_right_corner,
+    lowlight_attribute
+};
+
+}
+
+TEST_F(a_new_scroll_pane, lowlights_the_whole_frame_when_the_underlying_component_loses_focus)
+{
+    terminalpp::canvas canvas({4, 4});
+    munin::render_surface surface{canvas};
+
+    terminalpp::for_each_in_region(
+        canvas,
+        {{}, canvas.size()},
+        [](terminalpp::element &elem,
+           terminalpp::coordinate_type column,
+           terminalpp::coordinate_type row)
+        {
+            elem = 'X';
+        });
+
+    scroll_pane->set_size({4, 4});
+    scroll_pane->set_highlight_attribute(highlight_attribute);
+    scroll_pane->set_lowlight_attribute(lowlight_attribute);
+    
+    ON_CALL(*inner_component_, do_has_focus())
+        .WillByDefault(Return(true));
+    inner_component_->on_focus_set();
+
+    ON_CALL(*inner_component_, do_has_focus())
+        .WillByDefault(Return(false));
+    inner_component_->on_focus_lost();
+
+    scroll_pane->draw(surface, {{0, 0}, {4, 4}});
+
+    EXPECT_EQ(lowlighted_single_lined_rounded_top_left_corner,     canvas[0][0]);
+    EXPECT_EQ(lowlighted_single_lined_horizontal_beam,             canvas[1][0]);
+    EXPECT_EQ(lowlighted_single_lined_horizontal_beam,             canvas[2][0]);
+    EXPECT_EQ(lowlighted_single_lined_rounded_top_right_corner,    canvas[3][0]);
+    EXPECT_EQ(lowlighted_single_lined_vertical_beam,               canvas[0][1]);
+    EXPECT_EQ(terminalpp::element{'0'},                            canvas[1][1]);
+    EXPECT_EQ(terminalpp::element{'1'},                            canvas[2][1]);
+    EXPECT_EQ(lowlighted_single_lined_cross,                       canvas[3][1]);
+    EXPECT_EQ(lowlighted_single_lined_vertical_beam,               canvas[0][2]);
+    EXPECT_EQ(terminalpp::element{'1'},                            canvas[1][2]);
+    EXPECT_EQ(terminalpp::element{'2'},                            canvas[2][2]);
+    EXPECT_EQ(lowlighted_single_lined_vertical_beam,               canvas[3][2]);
+    EXPECT_EQ(lowlighted_single_lined_rounded_bottom_left_corner,  canvas[0][3]);
+    EXPECT_EQ(lowlighted_single_lined_cross,                       canvas[1][3]);
+    EXPECT_EQ(lowlighted_single_lined_horizontal_beam,             canvas[2][3]);
+    EXPECT_EQ(lowlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
+}

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -1,0 +1,101 @@
+#include <munin/scroll_pane.hpp>
+#include <munin/detail/unicode_glyphs.hpp>
+#include <munin/render_surface.hpp>
+#include <terminalpp/algorithm/for_each_in_region.hpp>
+#include "mock/component.hpp"
+#include <gtest/gtest.h>
+
+using testing::_;
+using testing::Return;
+using testing::ReturnPointee;
+using testing::SaveArg;
+using namespace terminalpp::literals;
+
+namespace {
+
+class a_new_scroll_pane : public testing::Test
+{
+public:
+    a_new_scroll_pane()
+    {
+        // Set up our mock component as a 10x10 grid of digits
+        ON_CALL(*inner_component_, do_draw(_, _))
+            .WillByDefault(
+                [this](munin::render_surface &surface, terminalpp::rectangle const &region)
+                {
+                    terminalpp::for_each_in_region(
+                        surface,
+                        region,
+                        [](terminalpp::element &elem,
+                           terminalpp::coordinate_type column,
+                           terminalpp::coordinate_type row)
+                        {
+                            elem = '0' + ((column + row) % 10);
+                        });
+                });
+
+        ON_CALL(*inner_component_, do_get_preferred_size)
+            .WillByDefault(Return(terminalpp::extent{10, 10}));
+
+        ON_CALL(*inner_component_, do_set_position(_))
+            .WillByDefault(SaveArg<0>(&mock_position));
+
+        ON_CALL(*inner_component_, do_get_position())
+            .WillByDefault(ReturnPointee(&mock_position));
+
+        ON_CALL(*inner_component_, do_set_size(_))
+            .WillByDefault(SaveArg<0>(&mock_size));
+
+        ON_CALL(*inner_component_, do_get_size())
+            .WillByDefault(ReturnPointee(&mock_size));
+    }
+
+protected:
+    terminalpp::point mock_position;
+    terminalpp::extent mock_size;
+    std::shared_ptr<mock_component> inner_component_ {
+        make_mock_component()
+    };
+
+    std::shared_ptr<munin::scroll_pane> scroll_pane {
+        munin::make_scroll_pane(inner_component_)
+    };
+};
+
+}
+
+TEST_F(a_new_scroll_pane, draws_the_component_within_its_frame)
+{
+    terminalpp::canvas canvas({4, 4});
+    munin::render_surface surface{canvas};
+
+    terminalpp::for_each_in_region(
+        canvas,
+        {{}, canvas.size()},
+        [](terminalpp::element &elem,
+           terminalpp::coordinate_type column,
+           terminalpp::coordinate_type row)
+        {
+            elem = 'X';
+        });
+
+    scroll_pane->set_size({4, 4});
+    scroll_pane->draw(surface, {{0, 0}, {4, 4}});
+
+    ASSERT_EQ(munin::detail::single_lined_rounded_top_left_corner,     canvas[0][0]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[1][0]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[2][0]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_top_right_corner,    canvas[3][0]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[0][1]);
+    ASSERT_EQ(terminalpp::element{'0'},                                canvas[1][1]);
+    ASSERT_EQ(terminalpp::element{'1'},                                canvas[2][1]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[3][1]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[0][2]);
+    ASSERT_EQ(terminalpp::element{'1'},                                canvas[1][2]);
+    ASSERT_EQ(terminalpp::element{'2'},                                canvas[2][2]);
+    ASSERT_EQ(munin::detail::single_lined_vertical_beam,               canvas[3][2]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_bottom_left_corner,  canvas[0][3]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[1][3]);
+    ASSERT_EQ(munin::detail::single_lined_horizontal_beam,             canvas[2][3]);
+    ASSERT_EQ(munin::detail::single_lined_rounded_bottom_right_corner, canvas[3][3]);
+}


### PR DESCRIPTION
Introduces scroll_pane, a class that wraps a tracked component into a viewport and implements vertical and horizontal scrollbars to track its positions.

Also changes edit controls so that cursors do not leave the bounds of the edit.  The position of the caret is instead tracked separately.  The control flow for a viewport observing such a control is thus that they receive a preferred size change and grant it, which causes the cursor to be updated to the caret position, which may cause the viewport to re-anchor.

Closes #57 
Closes #58

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/216)
<!-- Reviewable:end -->
