### PR TITLE
Viewports track shrinking components

### DIFF
--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -34,7 +34,7 @@ public:
                         });
                 });
 
-        ON_CALL(*inner_component_, do_get_preferred_size)
+        ON_CALL(*inner_component_, do_get_preferred_size())
             .WillByDefault(Return(terminalpp::extent{10, 10}));
 
         ON_CALL(*inner_component_, do_set_position(_))


### PR DESCRIPTION
When a tracked component shrinks in such a way that there is now
a part of the viewport that does not cover the tracked component,
then the viewport anchor moves to bring in more content from the
tracked component.  The cursor also moves relative to this shift.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/218)
<!-- Reviewable:end -->
