### PR TITLE
Edits emit a preferred size change on backspace

### DIFF
--- a/src/edit.cpp
+++ b/src/edit.cpp
@@ -219,6 +219,7 @@ private:
     
             --caret_position;
             update_cursor_position();
+            self_.on_preferred_size_changed();
             
             self_.on_redraw({{
                 { caret_position, 0 },

--- a/test/src/edit/edit_test.cpp
+++ b/test/src/edit/edit_test.cpp
@@ -286,3 +286,32 @@ TEST_F(an_edit_with_a_caret_out_of_view, updates_the_cursor_position_when_settin
         ASSERT_EQ(expected_cursor_position, edit_->get_cursor_position());
     }
 }
+
+namespace {
+
+class an_edit_with_content : public a_new_edit
+{
+public:
+    an_edit_with_content()
+    {
+        edit_->insert_text("test"_ts);
+    }
+};
+
+}
+
+TEST_F(an_edit_with_content, updates_the_preferred_size_when_text_is_deleted)
+{
+    auto preferred_size = terminalpp::extent{};
+    edit_->on_preferred_size_changed.connect(
+        [&]
+        {
+            preferred_size = edit_->get_preferred_size();
+        });
+
+    edit_->event(terminalpp::virtual_key{terminalpp::vk::bs});
+
+    // Prefer enough space for "tes_" (including cursor).
+    auto const expected_preferred_size = terminalpp::extent{4, 1};
+    ASSERT_EQ(expected_preferred_size, preferred_size);
+}

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -34,7 +34,7 @@ public:
                         });
                 });
 
-        ON_CALL(*inner_component_, do_get_preferred_size)
+        ON_CALL(*inner_component_, do_get_preferred_size())
             .WillByDefault(Return(terminalpp::extent{10, 10}));
 
         ON_CALL(*inner_component_, do_set_position(_))


### PR DESCRIPTION
This makes them behave properly when being controlled by a viewport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/219)
<!-- Reviewable:end -->
