### PR TITLE
Add options for resizing tracked components in viewports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ target_sources(munin_tester
         test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
         test/src/viewport/viewport_test.hpp
         test/src/viewport/viewport_test.cpp
+        test/src/viewport/viewport_growth_strategy_test.cpp
         test/src/viewport/viewport_cursor_test.cpp
         test/src/viewport/viewport_redraw_test.cpp
         test/src/viewport/viewport_size_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ target_sources(munin_tester
         test/src/vertical_strip_layout/vertical_strip_layout_test.cpp
         test/src/viewport/viewport_test.hpp
         test/src/viewport/viewport_test.cpp
-        test/src/viewport/viewport_growth_strategy_test.cpp
+        test/src/viewport/viewport_resize_strategy_test.cpp
         test/src/viewport/viewport_cursor_test.cpp
         test/src/viewport/viewport_redraw_test.cpp
         test/src/viewport/viewport_size_test.cpp

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "munin/framed_component.hpp"
+#include "munin/viewport.hpp"
 #include <memory>
 
 namespace munin {
@@ -16,6 +17,13 @@ public:
     /// \brief Constructor
     //* =====================================================================
     explicit scroll_pane(std::shared_ptr<component> const &inner_component);
+
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    scroll_pane(
+        std::shared_ptr<component> const &inner_component,
+        std::unique_ptr<viewport::growth_strategy> viewport_growth_strategy);
 
     //* =====================================================================
     /// \brief Destructor
@@ -44,7 +52,20 @@ private:
     std::unique_ptr<impl> pimpl_;
 };
 
+//* =========================================================================
+/// \brief Makes a new scroll pane around a given component.
+//* =========================================================================
 MUNIN_EXPORT
-std::shared_ptr<scroll_pane> make_scroll_pane(std::shared_ptr<component> const &inner_component);
+std::shared_ptr<scroll_pane> make_scroll_pane(
+    std::shared_ptr<component> const &inner_component);
+
+//* =========================================================================
+/// \brief Makes a new scroll around a given component with the specified
+/// growth strategy.
+//* =========================================================================
+MUNIN_EXPORT
+std::shared_ptr<scroll_pane> make_scroll_pane(
+    std::shared_ptr<component> const &inner_component,
+    std::unique_ptr<viewport::growth_strategy> strategy);
 
 }

--- a/include/munin/scroll_pane.hpp
+++ b/include/munin/scroll_pane.hpp
@@ -23,7 +23,7 @@ public:
     //* =====================================================================
     scroll_pane(
         std::shared_ptr<component> const &inner_component,
-        std::unique_ptr<viewport::growth_strategy> viewport_growth_strategy);
+        std::unique_ptr<viewport::resize_strategy> viewport_resize_strategy);
 
     //* =====================================================================
     /// \brief Destructor
@@ -61,11 +61,11 @@ std::shared_ptr<scroll_pane> make_scroll_pane(
 
 //* =========================================================================
 /// \brief Makes a new scroll around a given component with the specified
-/// growth strategy.
+/// resize strategy.
 //* =========================================================================
 MUNIN_EXPORT
 std::shared_ptr<scroll_pane> make_scroll_pane(
     std::shared_ptr<component> const &inner_component,
-    std::unique_ptr<viewport::growth_strategy> strategy);
+    std::unique_ptr<viewport::resize_strategy> strategy);
 
 }

--- a/include/munin/text_area.hpp
+++ b/include/munin/text_area.hpp
@@ -52,16 +52,6 @@ public:
         terminalpp::string const &text, 
         text_index position);
 
-    //* =====================================================================
-    /// \fn on_caret_position_changed
-    /// \brief Connect to this signal in order to receive notifications about
-    /// when the component's caret position changes.
-    //* =====================================================================
-    boost::signals2::signal
-    <
-        void ()
-    > on_caret_position_changed;
-
 protected:
     //* =====================================================================
     /// \brief Called by set_size().  Derived classes must override this

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -12,10 +12,37 @@ class MUNIN_EXPORT viewport : public basic_component
 {
 public:
     //* =====================================================================
+    /// \brief Defines a strategy by which a tracked component is allowed
+    /// to grow.
+    //* =====================================================================
+    struct growth_strategy
+    {
+        //* =================================================================
+        /// \brief Destructor
+        //* =================================================================
+        virtual ~growth_strategy() = default;
+
+        //* =================================================================
+        /// \brief Determine the new size of the tracked component given
+        /// its preferences and the viewport's current size.
+        //* =================================================================
+        virtual terminalpp::extent calculate_tracked_component_size(
+            terminalpp::extent tracked_preferred_size,
+            terminalpp::extent viewport_size) const = 0;
+    };
+
+    //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
     explicit viewport(std::shared_ptr<component> tracked_component);
     
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    viewport(
+        std::shared_ptr<component> tracked_component,
+        std::unique_ptr<growth_strategy> strategy);
+
     //* =====================================================================
     /// \brief Destructor
     //* =====================================================================
@@ -125,10 +152,42 @@ private:
 };
 
 //* =========================================================================
+/// \brief Returns a strategy where a viewport will grow the tracked 
+/// component in any direction it desires.
+//* =========================================================================
+MUNIN_EXPORT
+std::unique_ptr<viewport::growth_strategy> 
+    make_default_viewport_growth_strategy();
+
+//* =========================================================================
+/// \brief Returns a strategy where a viewport will only grow the tracked
+/// component in a vertical direction.
+//* =========================================================================
+MUNIN_EXPORT
+std::unique_ptr<viewport::growth_strategy> 
+    make_vertical_viewport_growth_strategy();
+
+//* =========================================================================
+/// \brief Returns a strategy where a viewport will only grow the tracked
+/// component in a horizontal direction.
+//* =========================================================================
+MUNIN_EXPORT
+std::unique_ptr<viewport::growth_strategy> 
+    make_horizontal_viewport_growth_strategy();
+
+//* =========================================================================
 /// \brief Returns a newly created viewport.
 //* =========================================================================
 MUNIN_EXPORT
 std::shared_ptr<viewport> make_viewport(
     std::shared_ptr<component> tracked_component);
+
+//* =========================================================================
+/// \brief Returns a newly created viewport with a given growth strategy.
+//* =========================================================================
+MUNIN_EXPORT
+std::shared_ptr<viewport> make_viewport(
+    std::shared_ptr<component> tracked_component,
+    std::unique_ptr<viewport::growth_strategy> strategy);
 
 }

--- a/include/munin/viewport.hpp
+++ b/include/munin/viewport.hpp
@@ -15,12 +15,12 @@ public:
     /// \brief Defines a strategy by which a tracked component is allowed
     /// to grow.
     //* =====================================================================
-    struct growth_strategy
+    struct resize_strategy
     {
         //* =================================================================
         /// \brief Destructor
         //* =================================================================
-        virtual ~growth_strategy() = default;
+        virtual ~resize_strategy() = default;
 
         //* =================================================================
         /// \brief Determine the new size of the tracked component given
@@ -41,7 +41,7 @@ public:
     //* =====================================================================
     viewport(
         std::shared_ptr<component> tracked_component,
-        std::unique_ptr<growth_strategy> strategy);
+        std::unique_ptr<resize_strategy> strategy);
 
     //* =====================================================================
     /// \brief Destructor
@@ -156,24 +156,24 @@ private:
 /// component in any direction it desires.
 //* =========================================================================
 MUNIN_EXPORT
-std::unique_ptr<viewport::growth_strategy> 
-    make_default_viewport_growth_strategy();
+std::unique_ptr<viewport::resize_strategy> 
+    make_default_viewport_resize_strategy();
 
 //* =========================================================================
 /// \brief Returns a strategy where a viewport will only grow the tracked
 /// component in a vertical direction.
 //* =========================================================================
 MUNIN_EXPORT
-std::unique_ptr<viewport::growth_strategy> 
-    make_vertical_viewport_growth_strategy();
+std::unique_ptr<viewport::resize_strategy> 
+    make_vertical_viewport_resize_strategy();
 
 //* =========================================================================
 /// \brief Returns a strategy where a viewport will only grow the tracked
 /// component in a horizontal direction.
 //* =========================================================================
 MUNIN_EXPORT
-std::unique_ptr<viewport::growth_strategy> 
-    make_horizontal_viewport_growth_strategy();
+std::unique_ptr<viewport::resize_strategy> 
+    make_horizontal_viewport_resize_strategy();
 
 //* =========================================================================
 /// \brief Returns a newly created viewport.
@@ -183,11 +183,11 @@ std::shared_ptr<viewport> make_viewport(
     std::shared_ptr<component> tracked_component);
 
 //* =========================================================================
-/// \brief Returns a newly created viewport with a given growth strategy.
+/// \brief Returns a newly created viewport with a given resize strategy.
 //* =========================================================================
 MUNIN_EXPORT
 std::shared_ptr<viewport> make_viewport(
     std::shared_ptr<component> tracked_component,
-    std::unique_ptr<viewport::growth_strategy> strategy);
+    std::unique_ptr<viewport::resize_strategy> strategy);
 
 }

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -41,6 +41,19 @@ scroll_pane::scroll_pane(std::shared_ptr<component> const &inner_component)
 // CONSTRUCTOR
 // ==========================================================================
 scroll_pane::scroll_pane(
+    std::shared_ptr<component> const &inner_component,
+    std::unique_ptr<viewport::growth_strategy> viewport_growth_strategy)
+  : scroll_pane(
+      make_scroll_frame(),
+      make_viewport(inner_component, std::move(viewport_growth_strategy)),
+      inner_component)
+{
+}
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+scroll_pane::scroll_pane(
     std::shared_ptr<component> const &inner_frame,
     std::shared_ptr<component> const &inner_viewport,
     std::shared_ptr<component> const &inner_component)
@@ -85,6 +98,17 @@ std::shared_ptr<scroll_pane> make_scroll_pane(
     std::shared_ptr<component> const &inner_component)
 {
     return std::make_shared<scroll_pane>(inner_component);
+}
+
+// ==========================================================================
+// MAKE_SCROLL_PANE
+// ==========================================================================
+std::shared_ptr<scroll_pane> make_scroll_pane(
+    std::shared_ptr<component> const &inner_component,
+    std::unique_ptr<viewport::growth_strategy> strategy)
+{
+    return std::make_shared<scroll_pane>(
+        inner_component, std::move(strategy));
 }
 
 }

--- a/src/scroll_pane.cpp
+++ b/src/scroll_pane.cpp
@@ -42,10 +42,10 @@ scroll_pane::scroll_pane(std::shared_ptr<component> const &inner_component)
 // ==========================================================================
 scroll_pane::scroll_pane(
     std::shared_ptr<component> const &inner_component,
-    std::unique_ptr<viewport::growth_strategy> viewport_growth_strategy)
+    std::unique_ptr<viewport::resize_strategy> viewport_resize_strategy)
   : scroll_pane(
       make_scroll_frame(),
-      make_viewport(inner_component, std::move(viewport_growth_strategy)),
+      make_viewport(inner_component, std::move(viewport_resize_strategy)),
       inner_component)
 {
 }
@@ -105,7 +105,7 @@ std::shared_ptr<scroll_pane> make_scroll_pane(
 // ==========================================================================
 std::shared_ptr<scroll_pane> make_scroll_pane(
     std::shared_ptr<component> const &inner_component,
-    std::unique_ptr<viewport::growth_strategy> strategy)
+    std::unique_ptr<viewport::resize_strategy> strategy)
 {
     return std::make_shared<scroll_pane>(
         inner_component, std::move(strategy));

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -2,7 +2,7 @@
 #include "munin/render_surface.hpp"
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <boost/make_unique.hpp>
-#include <boost/range/algorithm/for_each.hpp>
+#include <boost/range/algorithm/count_if.hpp>
 
 namespace munin {
 
@@ -179,28 +179,15 @@ void text_area::do_set_size(terminalpp::extent const &size)
 // ==========================================================================
 terminalpp::extent text_area::do_get_preferred_size() const
 {
-    terminalpp::coordinate_type preferred_rows = 1;
-    terminalpp::coordinate_type max_column_coordinate = 1;
-    terminalpp::coordinate_type current_x_coordinate = 0;
-    
-    boost::for_each(
-        pimpl_->text_,
-        [&](auto const &elem)
-        {
-            if (elem.glyph_.character_ == '\n')
-            {
-                ++preferred_rows;
-                current_x_coordinate = 0;
-            }
-            else
-            {
-                ++current_x_coordinate;
-                max_column_coordinate = 
-                    std::max(max_column_coordinate, current_x_coordinate);
-            }
-        });
-    
-    return {max_column_coordinate, preferred_rows};
+    return terminalpp::extent{
+        get_size().width_,
+        terminalpp::coordinate_type(
+            1 + boost::count_if(
+                pimpl_->text_,
+                [&](auto const &elem)
+                {
+                    return elem.glyph_.character_ == '\n';
+                }))};
 }
 
 // ==========================================================================

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -1,8 +1,9 @@
 #include "munin/text_area.hpp"
 #include "munin/render_surface.hpp"
 #include <terminalpp/algorithm/for_each_in_region.hpp>
+#include <boost/algorithm/clamp.hpp>
 #include <boost/make_unique.hpp>
-#include <boost/range/algorithm/count_if.hpp>
+#include <boost/range/algorithm_ext/insert.hpp>
 
 namespace munin {
 
@@ -20,6 +21,101 @@ struct text_area::impl
     }
 
     // ======================================================================
+    // GET_LENGTH
+    // ======================================================================
+    auto get_length() const
+    {
+        return text_area::text_index(text_.size());
+    }
+
+    // ======================================================================
+    // SET_CARET_POSITION
+    // ======================================================================
+    void set_caret_position(text_area::text_index position)
+    {
+        caret_position_ = boost::algorithm::clamp(
+            position,
+            0,
+            get_length());
+        update_cursor_position();
+    }
+
+    // ======================================================================
+    // UPDATE_CURSOR_POSITION
+    // ======================================================================
+    void update_cursor_position()
+    {
+        auto const text_area_width = self_.get_size().width_;
+        auto last_newline_index = text_area::text_index{0};
+        
+        auto cursor_position = terminalpp::point{};
+
+        for (text_area::text_index index = 0; index < caret_position_; ++index)
+        {
+            // If the character is a newline, then the cursor position only
+            // advances if it is not at the very end of a line.  This is to
+            // prevent it turning into a double newline in that circumstance.
+            if (text_[index] == '\n')
+            {
+                auto line_length = index - last_newline_index;
+                
+                if (line_length != text_area_width)
+                {
+                    cursor_position.x_ = 0;
+                    ++cursor_position.y_;
+                }
+                
+                last_newline_index = index;
+            }
+            else
+            {
+                ++cursor_position.x_;
+            }
+            
+            // Wrap the cursor if necessary.
+            if (cursor_position.x_ >= text_area_width)
+            {
+                cursor_position.x_ = 0;
+                ++cursor_position.y_;
+            }
+        }
+
+        cursor_position_ = cursor_position;
+        self_.on_cursor_position_changed();
+    }
+
+    // ======================================================================
+    // INSERT_TEXT
+    // ======================================================================
+    void insert_text(terminalpp::string const &text)
+    {
+        auto const new_caret_position = text_area::text_index(
+            get_length() + text.size());
+
+        boost::insert(text_, text_.begin() + caret_position_, text);
+        layout_text();
+
+        set_caret_position(new_caret_position);
+
+        self_.on_preferred_size_changed();
+        self_.on_redraw({{{}, self_.get_size()}});
+    }
+
+    // ======================================================================
+    // INSERT_TEXT
+    // ======================================================================
+    void insert_text(
+        terminalpp::string const &text, 
+        text_area::text_index position)
+    {
+        boost::insert(text_, text_.begin() + position, text);
+        layout_text();
+
+        self_.on_preferred_size_changed();
+        self_.on_redraw({{{}, self_.get_size()}});
+    }
+
+    // ======================================================================
     // LAYOUT_TEXT
     // ======================================================================
     void layout_text()
@@ -29,65 +125,32 @@ struct text_area::impl
 
         auto const text_area_width = self_.get_size().width_;
 
+        bool wrapped = false;
         for(auto const &ch : text_)
         {
             if (ch.glyph_.character_ == '\n')
             {
-                laid_out_text_.emplace_back();
+                // If we just wrapped a line, then absorb this newline.
+                if (!wrapped)
+                {
+                    laid_out_text_.emplace_back();
+                }
             }
             else
             {
                 laid_out_text_.back() += ch;
             }
-            
+
             if (laid_out_text_.back().size() == text_area_width)
             {
+                wrapped = true;
                 laid_out_text_.emplace_back();
-            }
-        }
-    }
-
-    // ======================================================================
-    // MOVE_CARET
-    // ======================================================================
-    void move_caret(text_area::text_index to_index)
-    {
-        auto const text_area_width = self_.get_size().width_;
-        auto last_newline_index = text_area::text_index{0};
-        
-        // For now, assume advance.
-        for(; caret_position_ != to_index; ++caret_position_)
-        {
-            // If the character is a newline, then the cursor position only
-            // advances if it is not at the very end of a line.  This is to
-            // prevent it turning into a double newline in that circumstance.
-            if (text_[caret_position_] == '\n')
-            {
-                auto line_length = caret_position_ - last_newline_index;
-                
-                if (line_length != text_area_width)
-                {
-                    cursor_position_.x_ = 0;
-                    ++cursor_position_.y_;
-                }
-                
-                last_newline_index = caret_position_;
             }
             else
             {
-                ++cursor_position_.x_;
-            }
-            
-            // Wrap the cursor if necessary.
-            if (cursor_position_.x_ >= text_area_width)
-            {
-                cursor_position_.x_ = 0;
-                ++cursor_position_.y_;
+                wrapped = false;
             }
         }
-
-        self_.on_caret_position_changed();
-        self_.on_cursor_position_changed();
     }
 
     text_area &self_;
@@ -124,7 +187,7 @@ text_area::text_index text_area::get_caret_position() const
 // ==========================================================================
 text_area::text_index text_area::get_length() const
 {
-    return 0;
+    return pimpl_->get_length();
 }
 
 // ==========================================================================
@@ -132,11 +195,7 @@ text_area::text_index text_area::get_length() const
 // ==========================================================================
 void text_area::insert_text(terminalpp::string const &text)
 {
-    insert_text(text, pimpl_->caret_position_);
-
-    auto const new_caret_position = static_cast<text_area::text_index>(
-        pimpl_->caret_position_ + text.size());
-    pimpl_->move_caret(new_caret_position);
+    pimpl_->insert_text(text);
 }
 
 // ==========================================================================
@@ -146,15 +205,7 @@ void text_area::insert_text(
     terminalpp::string const &text,
     text_area::text_index position)
 {
-    pimpl_->text_.insert(
-        pimpl_->text_.begin() + position, 
-        text.begin(),
-        text.end());
-
-    on_preferred_size_changed();
-    on_redraw({{{}, get_size()}});
-    
-    pimpl_->layout_text();
+    pimpl_->insert_text(text, position);
 }
 
 // ==========================================================================
@@ -162,16 +213,16 @@ void text_area::insert_text(
 // ==========================================================================
 void text_area::do_set_size(terminalpp::extent const &size)
 {
-    basic_component::do_set_size(size);
+    auto const old_preferred_size = get_preferred_size();
 
-    // The current caret/cursor position is based on the previous dimensions,
-    // but that has now all changed, so it needs to be worked out from first
-    // principles.
-    auto const saved_caret_position = pimpl_->caret_position_;
-    pimpl_->caret_position_ = 0;
-    pimpl_->cursor_position_ = {0, 0};
-    pimpl_->move_caret(saved_caret_position);
-    on_cursor_position_changed();
+    basic_component::do_set_size(size);
+    pimpl_->layout_text();
+    pimpl_->update_cursor_position();
+
+    if (get_preferred_size() != old_preferred_size)
+    {
+        on_preferred_size_changed();
+    }
 }
 
 // ==========================================================================
@@ -181,13 +232,9 @@ terminalpp::extent text_area::do_get_preferred_size() const
 {
     return terminalpp::extent{
         get_size().width_,
-        terminalpp::coordinate_type(
-            1 + boost::count_if(
-                pimpl_->text_,
-                [&](auto const &elem)
-                {
-                    return elem.glyph_.character_ == '\n';
-                }))};
+        std::max(
+            terminalpp::coordinate_type(1), 
+            terminalpp::coordinate_type(pimpl_->laid_out_text_.size()))};
 }
 
 // ==========================================================================

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -21,9 +21,9 @@ struct viewport::impl
     impl(
         viewport& self, 
         std::shared_ptr<component> tracked_component,
-        std::unique_ptr<viewport::growth_strategy> strategy)
+        std::unique_ptr<viewport::resize_strategy> strategy)
       : self_(self),
-        growth_strategy_(std::move(strategy)),
+        resize_strategy_(std::move(strategy)),
         tracked_component_(std::move(tracked_component))
     {
         tracked_component_->on_preferred_size_changed.connect(
@@ -178,21 +178,9 @@ struct viewport::impl
     void update_tracked_component_size()
     {
         tracked_component_->set_size(
-            growth_strategy_->calculate_tracked_component_size(
+            resize_strategy_->calculate_tracked_component_size(
                 tracked_component_->get_preferred_size(),
                 self_.get_size()));
-
-        /*
-        auto const preferred_size = tracked_component_->get_preferred_size();
-        auto const viewport_size = self_.get_size();
-        
-        auto const tracked_component_size = terminalpp::extent{
-            std::max(preferred_size.width_, viewport_size.width_),
-            std::max(preferred_size.height_, viewport_size.height_)
-        };
-        
-        tracked_component_->set_size(tracked_component_size);
-        */
     }
 
     // ======================================================================
@@ -341,7 +329,7 @@ private:
     }
 
     viewport &self_;
-    std::unique_ptr<viewport::growth_strategy> growth_strategy_;
+    std::unique_ptr<viewport::resize_strategy> resize_strategy_;
     std::shared_ptr<component> tracked_component_;
     terminalpp::rectangle anchor_bounds_;
     terminalpp::point cursor_position_;
@@ -353,7 +341,7 @@ private:
 viewport::viewport(std::shared_ptr<component> tracked_component)
   : viewport(
         std::move(tracked_component),
-        make_default_viewport_growth_strategy())
+        make_default_viewport_resize_strategy())
 {
 }
 
@@ -362,7 +350,7 @@ viewport::viewport(std::shared_ptr<component> tracked_component)
 // ==========================================================================
 viewport::viewport(
     std::shared_ptr<component> tracked_component,
-    std::unique_ptr<growth_strategy> strategy)
+    std::unique_ptr<resize_strategy> strategy)
   : pimpl_(
         boost::make_unique<impl>(
             *this, std::move(tracked_component), std::move(strategy)))
@@ -489,7 +477,7 @@ std::shared_ptr<viewport> make_viewport(
 // ==========================================================================
 std::shared_ptr<viewport> make_viewport(
     std::shared_ptr<component> tracked_component,
-    std::unique_ptr<viewport::growth_strategy> strategy)
+    std::unique_ptr<viewport::resize_strategy> strategy)
 {
     return std::make_shared<viewport>(
         std::move(tracked_component),
@@ -498,8 +486,8 @@ std::shared_ptr<viewport> make_viewport(
 
 namespace {
 
-class default_viewport_growth_strategy
-  : public viewport::growth_strategy
+class default_viewport_resize_strategy
+  : public viewport::resize_strategy
 {
     // ======================================================================
     // CALCULATE_TRACKED_COMPONENT_SIZE
@@ -516,10 +504,10 @@ class default_viewport_growth_strategy
 };
 
 // ==========================================================================
-// VERTICAL_VIEWPORT_GROWTH_STRATEGY
+// VERTICAL_VIEWPORT_RESIZE_STRATEGY
 // ==========================================================================
-class vertical_viewport_growth_strategy
-  : public viewport::growth_strategy
+class vertical_viewport_resize_strategy
+  : public viewport::resize_strategy
 {
     // ======================================================================
     // CALCULATE_TRACKED_COMPONENT_SIZE
@@ -536,10 +524,10 @@ class vertical_viewport_growth_strategy
 };
 
 // ==========================================================================
-// HORIZONTAL_VIEWPORT_GROWTH_STRATEGY
+// HORIZONTAL_VIEWPORT_RESIZE_STRATEGY
 // ==========================================================================
-class horizontal_viewport_growth_strategy
-  : public viewport::growth_strategy
+class horizontal_viewport_resize_strategy
+  : public viewport::resize_strategy
 {
     // ======================================================================
     // CALCULATE_TRACKED_COMPONENT_SIZE
@@ -558,30 +546,30 @@ class horizontal_viewport_growth_strategy
 }
 
 // ==========================================================================
-// MAKE_DEFAULT_VIEWPORT_GROWTH_STRATEGY
+// MAKE_DEFAULT_VIEWPORT_RESIZE_STRATEGY
 // ==========================================================================
-std::unique_ptr<viewport::growth_strategy> 
-    make_default_viewport_growth_strategy()
+std::unique_ptr<viewport::resize_strategy> 
+    make_default_viewport_resize_strategy()
 {
-    return boost::make_unique<default_viewport_growth_strategy>();
+    return boost::make_unique<default_viewport_resize_strategy>();
 }
 
 // ==========================================================================
-// MAKE_VERTICAL_VIEWPORT_GROWTH_STRATEGY
+// MAKE_VERTICAL_VIEWPORT_RESIZE_STRATEGY
 // ==========================================================================
-std::unique_ptr<viewport::growth_strategy> 
-    make_vertical_viewport_growth_strategy()
+std::unique_ptr<viewport::resize_strategy> 
+    make_vertical_viewport_resize_strategy()
 {
-    return boost::make_unique<vertical_viewport_growth_strategy>();
+    return boost::make_unique<vertical_viewport_resize_strategy>();
 }
 
 // ==========================================================================
-// MAKE_HORIZONTAL_VIEWPORT_GROWTH_STRATEGY
+// MAKE_HORIZONTAL_VIEWPORT_RESIZE_STRATEGY
 // ==========================================================================
-std::unique_ptr<viewport::growth_strategy> 
-    make_horizontal_viewport_growth_strategy()
+std::unique_ptr<viewport::resize_strategy> 
+    make_horizontal_viewport_resize_strategy()
 {
-    return boost::make_unique<horizontal_viewport_growth_strategy>();
+    return boost::make_unique<horizontal_viewport_resize_strategy>();
 }
 
 }

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -317,3 +317,28 @@ TEST_F(a_new_scroll_pane, lowlights_the_whole_frame_when_the_underlying_componen
     EXPECT_EQ(lowlighted_single_lined_horizontal_beam,             canvas[2][3]);
     EXPECT_EQ(lowlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
 }
+
+TEST(a_scroll_pane, with_a_resize_strategy_will_resize_the_tracked_component_accordingly)
+{
+    auto mock_component = make_mock_component();
+
+    auto component_size = terminalpp::extent{};
+    ON_CALL(*mock_component, do_set_size(_))
+        .WillByDefault(SaveArg<0>(&component_size));
+    ON_CALL(*mock_component, do_get_size())
+        .WillByDefault(ReturnPointee(&component_size));
+
+    auto const preferred_size = terminalpp::extent{10, 10};
+    ON_CALL(*mock_component, do_get_preferred_size())
+        .WillByDefault(Return(preferred_size));
+
+    auto scroll_pane = munin::make_scroll_pane(
+        mock_component,
+        munin::make_horizontal_viewport_resize_strategy());
+
+    scroll_pane->set_size({7, 7});
+
+    // The scroll pane reserves two rows for its border.
+    auto const expected_size = terminalpp::extent{10, 5};
+    ASSERT_EQ(expected_size, component_size);
+}

--- a/test/src/text_area/new_text_area_test.cpp
+++ b/test/src/text_area/new_text_area_test.cpp
@@ -79,7 +79,7 @@ TEST_F(a_new_text_area, announces_new_caret_and_cursor_positions_and_preferred_s
     ASSERT_EQ(terminalpp::point(1, 0), text_area_.get_cursor_position());
 
     ASSERT_TRUE(preferred_size_changed);
-    ASSERT_EQ(terminalpp::extent(1, 1), text_area_.get_preferred_size());
+    ASSERT_EQ(terminalpp::extent(2, 1), text_area_.get_preferred_size());
 }
 
 TEST_F(a_new_text_area, requests_a_redraw_and_draws_inserted_text_when_text_is_inserted)
@@ -236,23 +236,23 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn
     ({
         // Default position (nothing was inserted)
-        text_area_layout_data{{3, 2}, ""_ts, {1, 1}, 0, {0, 0}},
+        text_area_layout_data{{3, 2}, ""_ts,        {3, 1}, 0, {0, 0}},
         
         // Insertions that do not require flow (manual newlines only)
-        text_area_layout_data{{3, 2}, "a"_ts, {1, 1}, 1, {1, 0}},
-        text_area_layout_data{{3, 2}, "ab"_ts, {2, 1}, 2, {2, 0}},
-        text_area_layout_data{{3, 2}, "a\nb"_ts, {1, 2}, 3, {1, 1}},
-        text_area_layout_data{{3, 2}, "ab\n"_ts, {2, 2}, 3, {0, 1}},
-        text_area_layout_data{{3, 2}, "ab\nc"_ts, {2, 2}, 4, {1, 1}},
-        text_area_layout_data{{3, 2}, "abc"_ts, {3, 1}, 3, {0, 1}},
+        text_area_layout_data{{3, 2}, "a"_ts,       {3, 1}, 1, {1, 0}},
+        text_area_layout_data{{3, 2}, "ab"_ts,      {3, 1}, 2, {2, 0}},
+        text_area_layout_data{{3, 2}, "a\nb"_ts,    {3, 2}, 3, {1, 1}},
+        text_area_layout_data{{3, 2}, "ab\n"_ts,    {3, 2}, 3, {0, 1}},
+        text_area_layout_data{{3, 2}, "ab\nc"_ts,   {3, 2}, 4, {1, 1}},
+        text_area_layout_data{{3, 2}, "abc"_ts,     {3, 1}, 3, {0, 1}},
         
         // Insertions that require flow (had an automatic split)
-        text_area_layout_data{{3, 2}, "abcd"_ts, {4, 1}, 4, {1, 1}},
-        text_area_layout_data{{3, 2}, "abcde"_ts, {5, 1}, 5, {2, 1}},
-        text_area_layout_data{{3, 2}, "abcdefg"_ts, {7, 1}, 7, {1, 2}},
+        text_area_layout_data{{3, 2}, "abcd"_ts,    {3, 1}, 4, {1, 1}},
+        text_area_layout_data{{3, 2}, "abcde"_ts,   {3, 1}, 5, {2, 1}},
+        text_area_layout_data{{3, 2}, "abcdefg"_ts, {3, 1}, 7, {1, 2}},
         
         // Insertions that have an explicit newline on the boundary
-        text_area_layout_data{{3, 2}, "abc\n", {3, 2}, 4, {0, 1}},
+        text_area_layout_data{{3, 2}, "abc\n",      {3, 2}, 4, {0, 1}},
     })
 );
 
@@ -300,7 +300,7 @@ TEST_F(a_new_text_area, does_not_move_the_caret_when_inserting_at_a_specified_in
     ASSERT_EQ(terminalpp::point(0, 0), text_area_.get_cursor_position());
 
     ASSERT_TRUE(preferred_size_changed);
-    ASSERT_EQ(terminalpp::extent(1, 1), text_area_.get_preferred_size());
+    ASSERT_EQ(terminalpp::extent(2, 1), text_area_.get_preferred_size());
 
     ASSERT_TRUE(redraw_requested);
     

--- a/test/src/text_area/new_text_area_test.cpp
+++ b/test/src/text_area/new_text_area_test.cpp
@@ -29,6 +29,13 @@ TEST_F(a_new_text_area, has_length_zero)
     ASSERT_EQ(0, text_area_.get_length());
 }
 
+TEST_F(a_new_text_area, has_preferred_size_of_0x1)
+{
+    // The preferred size always has width of its current size, but it also
+    // wants a line to put the cursor in.
+    ASSERT_EQ(terminalpp::extent(0, 1), text_area_.get_preferred_size());
+}
+
 TEST_F(a_new_text_area, draws_only_spaces)
 {
     text_area_.set_size({2, 2});
@@ -45,16 +52,9 @@ TEST_F(a_new_text_area, draws_only_spaces)
     verify_oob_is_untouched();
 }
 
-TEST_F(a_new_text_area, announces_new_caret_and_cursor_positions_and_preferred_size_when_inserting_text_at_the_caret)
+TEST_F(a_new_text_area, announces_cursor_position_change_when_inserting_text_at_the_caret)
 {
     text_area_.set_size({2, 2});
-
-    bool caret_position_changed = false;
-    text_area_.on_caret_position_changed.connect(
-        [&caret_position_changed]()
-        {
-            caret_position_changed = true;
-        });
 
     bool cursor_position_changed = false;
     text_area_.on_cursor_position_changed.connect(
@@ -63,23 +63,13 @@ TEST_F(a_new_text_area, announces_new_caret_and_cursor_positions_and_preferred_s
             cursor_position_changed = true;
         });
 
-    bool preferred_size_changed = false;
-    text_area_.on_preferred_size_changed.connect(
-        [&preferred_size_changed]()
-        {
-            preferred_size_changed = true;
-        });
-
     text_area_.insert_text("a"_ts);
-
-    ASSERT_TRUE(caret_position_changed);
-    ASSERT_EQ(1, text_area_.get_caret_position());
 
     ASSERT_TRUE(cursor_position_changed);
     ASSERT_EQ(terminalpp::point(1, 0), text_area_.get_cursor_position());
-
-    ASSERT_TRUE(preferred_size_changed);
+    ASSERT_EQ(1, text_area_.get_caret_position());
     ASSERT_EQ(terminalpp::extent(2, 1), text_area_.get_preferred_size());
+    ASSERT_EQ(munin::text_area::text_index{1}, text_area_.get_length());
 }
 
 TEST_F(a_new_text_area, requests_a_redraw_and_draws_inserted_text_when_text_is_inserted)
@@ -244,12 +234,12 @@ INSTANTIATE_TEST_SUITE_P(
         text_area_layout_data{{3, 2}, "a\nb"_ts,    {3, 2}, 3, {1, 1}},
         text_area_layout_data{{3, 2}, "ab\n"_ts,    {3, 2}, 3, {0, 1}},
         text_area_layout_data{{3, 2}, "ab\nc"_ts,   {3, 2}, 4, {1, 1}},
-        text_area_layout_data{{3, 2}, "abc"_ts,     {3, 1}, 3, {0, 1}},
+        text_area_layout_data{{3, 2}, "abc"_ts,     {3, 2}, 3, {0, 1}},
         
         // Insertions that require flow (had an automatic split)
-        text_area_layout_data{{3, 2}, "abcd"_ts,    {3, 1}, 4, {1, 1}},
-        text_area_layout_data{{3, 2}, "abcde"_ts,   {3, 1}, 5, {2, 1}},
-        text_area_layout_data{{3, 2}, "abcdefg"_ts, {3, 1}, 7, {1, 2}},
+        text_area_layout_data{{3, 2}, "abcd"_ts,    {3, 2}, 4, {1, 1}},
+        text_area_layout_data{{3, 2}, "abcde"_ts,   {3, 2}, 5, {2, 1}},
+        text_area_layout_data{{3, 2}, "abcdefg"_ts, {3, 3}, 7, {1, 2}},
         
         // Insertions that have an explicit newline on the boundary
         text_area_layout_data{{3, 2}, "abc\n",      {3, 2}, 4, {0, 1}},
@@ -259,13 +249,6 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_F(a_new_text_area, does_not_move_the_caret_when_inserting_at_a_specified_index_but_still_inserts_the_text)
 {
     text_area_.set_size({2, 2});
-
-    bool caret_position_changed = false;
-    text_area_.on_caret_position_changed.connect(
-        [&caret_position_changed]()
-        {
-            caret_position_changed = true;
-        });
 
     bool cursor_position_changed = false;
     text_area_.on_cursor_position_changed.connect(
@@ -293,14 +276,13 @@ TEST_F(a_new_text_area, does_not_move_the_caret_when_inserting_at_a_specified_in
 
     text_area_.insert_text("a"_ts, 0);
 
-    ASSERT_FALSE(caret_position_changed);
-    ASSERT_EQ(0, text_area_.get_caret_position());
+    ASSERT_TRUE(preferred_size_changed);
+    ASSERT_EQ(terminalpp::extent(2, 1), text_area_.get_preferred_size());
 
     ASSERT_FALSE(cursor_position_changed);
     ASSERT_EQ(terminalpp::point(0, 0), text_area_.get_cursor_position());
 
-    ASSERT_TRUE(preferred_size_changed);
-    ASSERT_EQ(terminalpp::extent(2, 1), text_area_.get_preferred_size());
+    ASSERT_EQ(0, text_area_.get_caret_position());
 
     ASSERT_TRUE(redraw_requested);
     

--- a/test/src/text_area/text_area_with_text_inserted_test.cpp
+++ b/test/src/text_area/text_area_with_text_inserted_test.cpp
@@ -132,3 +132,22 @@ TEST_F(a_text_area_with_text_inserted, lays_out_its_text_when_the_size_changes)
     verify_oob_is_untouched();
 }
 
+TEST_F(a_text_area_with_text_inserted, announces_a_change_in_preferred_size_if_its_size_is_changed_such_that_there_are_now_more_lines)
+{
+    // for example, if I change the size of "ab" to 1x1 such that the b would
+    // now bleed into the next line, the text area should request the new
+    // preferred height.
+    text_area_.set_size({2, 1});
+
+    auto preferred_size = terminalpp::extent{};
+    text_area_.on_preferred_size_changed.connect(
+        [&]
+        {
+            preferred_size = text_area_.get_preferred_size();
+        });
+
+    text_area_.set_size({1, 1});
+
+    auto const expected_preferred_size = terminalpp::extent{1, 3};
+    ASSERT_EQ(expected_preferred_size, preferred_size);
+}

--- a/test/src/viewport/viewport_growth_strategy_test.cpp
+++ b/test/src/viewport/viewport_growth_strategy_test.cpp
@@ -1,0 +1,63 @@
+#include "viewport_test.hpp"
+#include <gtest/gtest.h>
+
+using testing::Return;
+
+namespace {
+
+class a_viewport_with_a_vertical_growth_strategy
+  : public a_viewport
+{
+public:
+    a_viewport_with_a_vertical_growth_strategy()
+    {
+        viewport_ = munin::make_viewport(
+            tracked_component_,
+            munin::make_vertical_viewport_growth_strategy());
+    }
+};
+
+}
+
+TEST_F(a_viewport_with_a_vertical_growth_strategy, is_granted_vertical_but_not_horizontal_size_when_the_viewport_is_resized)
+{
+    auto const tracked_preferred_size = terminalpp::extent{10, 10};
+
+    ON_CALL(*tracked_component_, do_get_preferred_size())
+        .WillByDefault(Return(tracked_preferred_size));
+
+    viewport_->set_size({5, 5});
+
+    auto const expected_tracked_size = terminalpp::extent{5, 10};
+    ASSERT_EQ(expected_tracked_size, tracked_component_->get_size());
+}
+
+namespace {
+
+class a_viewport_with_a_horizontal_growth_strategy
+  : public a_viewport
+{
+public:
+    a_viewport_with_a_horizontal_growth_strategy()
+    {
+        viewport_ = munin::make_viewport(
+            tracked_component_,
+            munin::make_horizontal_viewport_growth_strategy());
+    }
+};
+
+}
+
+TEST_F(a_viewport_with_a_horizontal_growth_strategy, is_granted_horizontal_but_not_vertical_size_when_the_viewport_is_resized)
+{
+    auto const tracked_preferred_size = terminalpp::extent{10, 10};
+
+    ON_CALL(*tracked_component_, do_get_preferred_size())
+        .WillByDefault(Return(tracked_preferred_size));
+
+    viewport_->set_size({5, 5});
+
+    auto const expected_tracked_size = terminalpp::extent{10, 5};
+    ASSERT_EQ(expected_tracked_size, tracked_component_->get_size());
+}
+

--- a/test/src/viewport/viewport_resize_strategy_test.cpp
+++ b/test/src/viewport/viewport_resize_strategy_test.cpp
@@ -5,21 +5,21 @@ using testing::Return;
 
 namespace {
 
-class a_viewport_with_a_vertical_growth_strategy
+class a_viewport_with_a_vertical_resize_strategy
   : public a_viewport
 {
 public:
-    a_viewport_with_a_vertical_growth_strategy()
+    a_viewport_with_a_vertical_resize_strategy()
     {
         viewport_ = munin::make_viewport(
             tracked_component_,
-            munin::make_vertical_viewport_growth_strategy());
+            munin::make_vertical_viewport_resize_strategy());
     }
 };
 
 }
 
-TEST_F(a_viewport_with_a_vertical_growth_strategy, is_granted_vertical_but_not_horizontal_size_when_the_viewport_is_resized)
+TEST_F(a_viewport_with_a_vertical_resize_strategy, is_granted_vertical_but_not_horizontal_size_when_the_viewport_is_resized)
 {
     auto const tracked_preferred_size = terminalpp::extent{10, 10};
 
@@ -34,21 +34,21 @@ TEST_F(a_viewport_with_a_vertical_growth_strategy, is_granted_vertical_but_not_h
 
 namespace {
 
-class a_viewport_with_a_horizontal_growth_strategy
+class a_viewport_with_a_horizontal_resize_strategy
   : public a_viewport
 {
 public:
-    a_viewport_with_a_horizontal_growth_strategy()
+    a_viewport_with_a_horizontal_resize_strategy()
     {
         viewport_ = munin::make_viewport(
             tracked_component_,
-            munin::make_horizontal_viewport_growth_strategy());
+            munin::make_horizontal_viewport_resize_strategy());
     }
 };
 
 }
 
-TEST_F(a_viewport_with_a_horizontal_growth_strategy, is_granted_horizontal_but_not_vertical_size_when_the_viewport_is_resized)
+TEST_F(a_viewport_with_a_horizontal_resize_strategy, is_granted_horizontal_but_not_vertical_size_when_the_viewport_is_resized)
 {
     auto const tracked_preferred_size = terminalpp::extent{10, 10};
 
@@ -60,4 +60,3 @@ TEST_F(a_viewport_with_a_horizontal_growth_strategy, is_granted_horizontal_but_n
     auto const expected_tracked_size = terminalpp::extent{10, 5};
     ASSERT_EQ(expected_tracked_size, tracked_component_->get_size());
 }
-


### PR DESCRIPTION
Previously, growing a tracked component in a viewport would happily stretch the tracked component in any direction.  However, shrinking the viewport would not shrink the tracked component.

For example, by placing a text area in a viewport, text would start off wrapped, unwrap as it grew horizontally, and then flow off the side when the viewport was resized to be smaller.  Ideally, the text would re-wrap.

To allow this behaviour, a viewport (and scroll_pane transitively) can accept a resize_strategy, which indicates how resizes can occur.  Combining a text area with a viewport that has the vertical resize strategy will ensure that the text area is only ever as wide as the viewport, while it can still extent vertically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/224)
<!-- Reviewable:end -->
