### PR TITLE
Refactored all uses of testing::Invoke into more appropriate code.

### DIFF
--- a/test/src/container/container_event_test.cpp
+++ b/test/src/container/container_event_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 using testing::_;
-using testing::Invoke;
 using testing::Return;
 using testing::TestWithParam;
 using testing::ValuesIn;
@@ -25,12 +24,13 @@ TEST_F(a_container_with_one_component_that_has_focus, forwards_events_to_the_sub
         .WillOnce(Return(true));
 
     EXPECT_CALL(*component, do_event(_))
-        .WillOnce(Invoke([](boost::any const &event)
-        {
-            char const *p = boost::any_cast<char>(&event);
-            ASSERT_NE(nullptr, p);
-            ASSERT_EQ('X', *p);
-        }));
+        .WillOnce(
+            [](boost::any const &event)
+            {
+                char const *p = boost::any_cast<char>(&event);
+                ASSERT_NE(nullptr, p);
+                ASSERT_EQ('X', *p);
+            });
     container.event('X');
 }
 
@@ -43,12 +43,13 @@ TEST_F(a_container_with_two_components_where_the_last_has_focus, skips_the_first
         .WillOnce(Return(true));
 
     EXPECT_CALL(*component1, do_event(_))
-        .WillOnce(Invoke([](boost::any const &event)
-        {
-            char const *p = boost::any_cast<char>(&event);
-            ASSERT_NE(nullptr, p);
-            ASSERT_EQ('X', *p);
-        }));
+        .WillOnce(
+            [](boost::any const &event)
+            {
+                char const *p = boost::any_cast<char>(&event);
+                ASSERT_NE(nullptr, p);
+                ASSERT_EQ('X', *p);
+            });
     container.event('X');
 }
 
@@ -66,12 +67,13 @@ TEST_F(a_container_with_one_component, forwards_mouse_events_even_though_the_com
         .WillOnce(Return(terminalpp::extent(10, 10)));
 
     EXPECT_CALL(*component, do_event(_))
-        .WillOnce(Invoke([](boost::any const &event)
-        {
-            auto *p = boost::any_cast<terminalpp::mouse::event>(&event);
-            ASSERT_NE(nullptr, p);
-            ASSERT_EQ(ev, *p);
-        }));
+        .WillOnce(
+            [](boost::any const &event)
+            {
+                auto *p = boost::any_cast<terminalpp::mouse::event>(&event);
+                ASSERT_NE(nullptr, p);
+                ASSERT_EQ(ev, *p);
+            });
 
     container.event(ev);
 }
@@ -100,13 +102,14 @@ TEST_P(containers_forwarding_mouse_events, translate_coordinates_relative_to_com
         .WillOnce(Return(component_size));
 
     EXPECT_CALL(*component, do_event(_))
-        .WillOnce(Invoke([&expected_value](boost::any event)
-        {
-            auto *mouse_event = 
-                boost::any_cast<terminalpp::mouse::event>(&event);
-            ASSERT_NE(nullptr, mouse_event);
-            ASSERT_EQ(expected_value, *mouse_event);
-        }));
+        .WillOnce(
+            [&expected_value](boost::any event)
+            {
+                auto *mouse_event = 
+                    boost::any_cast<terminalpp::mouse::event>(&event);
+                ASSERT_NE(nullptr, mouse_event);
+                ASSERT_EQ(expected_value, *mouse_event);
+            });
     container.event(event);
 }
 
@@ -165,12 +168,13 @@ TEST_F(a_container_with_two_components, skips_components_that_are_not_at_the_mou
         .WillOnce(Return(terminalpp::extent(10, 10)));
 
     EXPECT_CALL(*component1, do_event(_))
-        .WillOnce(Invoke([](boost::any event)
-        {
-            auto *report = boost::any_cast<terminalpp::mouse::event>(&event);
-            ASSERT_NE(nullptr, report);
-            ASSERT_EQ(expected_value, *report);
-        }));
+        .WillOnce(
+            [](boost::any event)
+            {
+                auto *report = boost::any_cast<terminalpp::mouse::event>(&event);
+                ASSERT_NE(nullptr, report);
+                ASSERT_EQ(expected_value, *report);
+            });
 
     container.event(event);
 }

--- a/test/src/container/container_focus_next_test.cpp
+++ b/test/src/container/container_focus_next_test.cpp
@@ -1,7 +1,6 @@
 #include "container_test.hpp"
 
 using testing::InSequence;
-using testing::Invoke;
 using testing::Return;
 
 TEST_F(a_container_with_one_component, calls_focus_next_on_subcomponent_on_focus_next)
@@ -12,7 +11,7 @@ TEST_F(a_container_with_one_component, calls_focus_next_on_subcomponent_on_focus
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_next())
-            .WillOnce(Invoke(std::ref(component->on_focus_set)));
+            .WillOnce(std::ref(component->on_focus_set));
         EXPECT_CALL(*component, do_has_focus())
             .WillRepeatedly(Return(true));
     }
@@ -57,7 +56,7 @@ TEST_F(a_container_with_two_components, skips_components_that_refuse_focus_next_
             .WillRepeatedly(Return(false));
 
         EXPECT_CALL(*component1, do_focus_next())
-            .WillOnce(Invoke(std::ref(component1->on_focus_set)));
+            .WillOnce(std::ref(component1->on_focus_set));
         EXPECT_CALL(*component1, do_has_focus())
             .WillRepeatedly(Return(true));
     }
@@ -94,12 +93,12 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, calls_next_foc
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(true));
         EXPECT_CALL(*component0, do_focus_next())
-            .WillOnce(Invoke(std::ref(component0->on_focus_lost)));
+            .WillOnce(std::ref(component0->on_focus_lost));
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(false));
 
         EXPECT_CALL(*component1, do_focus_next())
-            .WillOnce(Invoke(std::ref(component1->on_focus_set)));
+            .WillOnce(std::ref(component1->on_focus_set));
         EXPECT_CALL(*component1, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -118,7 +117,7 @@ TEST_F(a_container_with_three_components_where_the_first_has_focus, skips_compon
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(true));
         EXPECT_CALL(*component0, do_focus_next())
-            .WillOnce(Invoke(std::ref(component0->on_focus_lost)));
+            .WillOnce(std::ref(component0->on_focus_lost));
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(false));
 
@@ -127,7 +126,7 @@ TEST_F(a_container_with_three_components_where_the_first_has_focus, skips_compon
             .WillOnce(Return(false));
 
         EXPECT_CALL(*component2, do_focus_next())
-            .WillOnce(Invoke(std::ref(component2->on_focus_set)));
+            .WillOnce(std::ref(component2->on_focus_set));
         EXPECT_CALL(*component2, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -146,7 +145,7 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, loses_focus_on
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(true));
         EXPECT_CALL(*component0, do_focus_next())
-            .WillOnce(Invoke(std::ref(component0->on_focus_lost)));
+            .WillOnce(std::ref(component0->on_focus_lost));
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(false));
 

--- a/test/src/container/container_focus_previous_test.cpp
+++ b/test/src/container/container_focus_previous_test.cpp
@@ -1,7 +1,6 @@
 #include "container_test.hpp"
 
 using testing::InSequence;
-using testing::Invoke;
 using testing::Return;
 
 TEST_F(a_container_with_one_component, calls_focus_previous_on_subcomponent_on_focus_previous)
@@ -12,7 +11,7 @@ TEST_F(a_container_with_one_component, calls_focus_previous_on_subcomponent_on_f
     {
         InSequence s1;
         EXPECT_CALL(*component, do_focus_previous())
-            .WillOnce(Invoke(std::ref(component->on_focus_set)));
+            .WillOnce(std::ref(component->on_focus_set));
         EXPECT_CALL(*component, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -57,7 +56,7 @@ TEST_F(a_container_with_two_components, skips_components_that_refuse_focus_previ
             .WillRepeatedly(Return(false));
 
         EXPECT_CALL(*component0, do_focus_previous())
-            .WillOnce(Invoke(std::ref(component0->on_focus_set)));
+            .WillOnce(std::ref(component0->on_focus_set));
         EXPECT_CALL(*component0, do_has_focus())
             .WillRepeatedly(Return(true));
     }
@@ -94,7 +93,7 @@ TEST_F(a_container_with_three_components_where_the_last_has_focus, skips_compone
         EXPECT_CALL(*component2, do_has_focus())
             .WillOnce(Return(true));
         EXPECT_CALL(*component2, do_focus_previous())
-            .WillOnce(Invoke(std::ref(component2->on_focus_lost)));
+            .WillOnce(std::ref(component2->on_focus_lost));
         EXPECT_CALL(*component2, do_has_focus())
             .WillOnce(Return(false));
 
@@ -103,7 +102,7 @@ TEST_F(a_container_with_three_components_where_the_last_has_focus, skips_compone
             .WillOnce(Return(false));
 
         EXPECT_CALL(*component0, do_focus_previous())
-            .WillOnce(Invoke(std::ref(component0->on_focus_set)));
+            .WillOnce(std::ref(component0->on_focus_set));
         EXPECT_CALL(*component0, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -122,7 +121,7 @@ TEST_F(a_container_with_two_components_where_the_last_has_focus, loses_focus_on_
         EXPECT_CALL(*component1, do_has_focus())
             .WillOnce(Return(true));
         EXPECT_CALL(*component1, do_focus_previous())
-            .WillOnce(Invoke(std::ref(component1->on_focus_lost)));
+            .WillOnce(std::ref(component1->on_focus_lost));
         EXPECT_CALL(*component1, do_has_focus())
             .WillOnce(Return(false));
 

--- a/test/src/container/container_focus_test.cpp
+++ b/test/src/container/container_focus_test.cpp
@@ -1,7 +1,6 @@
 #include "container_test.hpp"
 
 using testing::InSequence;
-using testing::Invoke;
 using testing::Return;
 
 TEST_F(a_container, when_focus_is_set_gives_focus_to_the_first_component)
@@ -13,7 +12,7 @@ TEST_F(a_container, when_focus_is_set_gives_focus_to_the_first_component)
     {
         InSequence s1;
         EXPECT_CALL(*component, do_set_focus())
-            .WillOnce(Invoke(std::ref(component->on_focus_set)));
+            .WillOnce(std::ref(component->on_focus_set));
         EXPECT_CALL(*component, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -40,7 +39,7 @@ TEST_F(a_container, when_focus_is_set_skips_over_unfocusable_components)
             .WillOnce(Return(false));
 
         EXPECT_CALL(*focusable_component, do_set_focus())
-            .WillOnce(Invoke(std::ref(focusable_component->on_focus_set)));
+            .WillOnce(std::ref(focusable_component->on_focus_set));
         EXPECT_CALL(*focusable_component, do_has_focus())
             .WillOnce(Return(true));
     }
@@ -77,7 +76,7 @@ TEST_F(a_container_with_one_component_that_has_focus, loses_focus_from_focused_c
     EXPECT_CALL(*component, do_has_focus())
         .WillOnce(Return(true));
     EXPECT_CALL(*component, do_lose_focus())
-        .WillOnce(Invoke(std::ref(component->on_focus_lost)));
+        .WillOnce(std::ref(component->on_focus_lost));
 
     container.lose_focus();
 

--- a/test/src/container/container_layout_test.cpp
+++ b/test/src/container/container_layout_test.cpp
@@ -2,9 +2,7 @@
 #include "mock/layout.hpp"
 
 using testing::_;
-using testing::DoAll;
 using testing::InSequence;
-using testing::Invoke;
 using testing::Return;
 
 TEST(a_container_with_no_elements, does_not_lay_the_container_out_when_a_component_is_added)

--- a/test/src/container/container_subcomponent_focus_test.cpp
+++ b/test/src/container/container_subcomponent_focus_test.cpp
@@ -1,7 +1,6 @@
 #include "container_test.hpp"
 
 using testing::InSequence;
-using testing::Invoke;
 using testing::Return;
 
 TEST_F(a_container_with_one_component, sets_focus_when_component_sets_focus)
@@ -25,7 +24,7 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, removes_focus_
     EXPECT_CALL(*component0, do_has_focus())
         .WillOnce(Return(true));
     EXPECT_CALL(*component0, do_lose_focus())
-        .WillOnce(Invoke(std::ref(component0->on_focus_lost)));
+        .WillOnce(std::ref(component0->on_focus_lost));
 
     component1->on_focus_set();
 
@@ -41,7 +40,7 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, announces_curs
         ON_CALL(*component0, do_has_focus())
             .WillByDefault(Return(true));
         ON_CALL(*component0, do_lose_focus())
-            .WillByDefault(Invoke(std::ref(component0->on_focus_lost)));
+            .WillByDefault(std::ref(component0->on_focus_lost));
         ON_CALL(*component0, do_has_focus())
             .WillByDefault(Return(false));
     }
@@ -51,7 +50,7 @@ TEST_F(a_container_with_two_components_where_the_first_has_focus, announces_curs
         ON_CALL(*component1, do_has_focus())
             .WillByDefault(Return(false));
         ON_CALL(*component1, do_set_focus())
-            .WillByDefault(Invoke(std::ref(component0->on_focus_set)));
+            .WillByDefault(std::ref(component0->on_focus_set));
         ON_CALL(*component1, do_has_focus())
             .WillByDefault(Return(true));
     }
@@ -67,7 +66,7 @@ TEST_F(a_container_with_two_components_where_the_last_has_focus, removes_focus_f
     EXPECT_CALL(*component1, do_has_focus())
         .WillOnce(Return(true));
     EXPECT_CALL(*component1, do_lose_focus())
-        .WillOnce(Invoke(std::ref(component1->on_focus_lost)));
+        .WillOnce(std::ref(component1->on_focus_lost));
 
     component0->on_focus_set();
 

--- a/test/src/framed_component/framed_component_focus_test.cpp
+++ b/test/src/framed_component/framed_component_focus_test.cpp
@@ -3,8 +3,10 @@
 #include <munin/framed_component.hpp>
 #include <gtest/gtest.h>
 
-using testing::Invoke;
+using testing::Assign;
+using testing::DoAll;
 using testing::Return;
+using testing::ReturnPointee;
 using testing::_;
 
 namespace {
@@ -41,14 +43,6 @@ class a_framed_component_with_an_inner_component_that_takes_no_focus
 protected:
     a_framed_component_with_an_inner_component_that_takes_no_focus()
     {
-        ON_CALL(*mock_inner_, do_set_focus())
-            .WillByDefault(Return());
-        ON_CALL(*mock_inner_, do_lose_focus())
-            .WillByDefault(Return());
-        ON_CALL(*mock_inner_, do_focus_next())
-            .WillByDefault(Return());
-        ON_CALL(*mock_inner_, do_focus_previous())
-            .WillByDefault(Return());
         ON_CALL(*mock_inner_, do_has_focus())
             .WillByDefault(Return(false));
     }
@@ -92,25 +86,22 @@ protected:
     a_framed_component_with_an_inner_component_that_can_have_focus_set()
     {
         ON_CALL(*mock_inner_, do_set_focus())
-            .WillByDefault(Invoke([this]{
-                has_focus_ = true;
-                mock_inner_->on_focus_set();
-            }));
+            .WillByDefault(DoAll(
+                Assign(&has_focus_, true),
+                std::ref(mock_inner_->on_focus_set)));
 
         ON_CALL(*mock_inner_, do_focus_next())
-            .WillByDefault(Invoke([this]{
-                has_focus_ = true;
-                mock_inner_->on_focus_set();
-            }));
+            .WillByDefault(DoAll(
+                Assign(&has_focus_, true),
+                std::ref(mock_inner_->on_focus_set)));
 
         ON_CALL(*mock_inner_, do_focus_previous())
-            .WillByDefault(Invoke([this]{
-                has_focus_ = true;
-                mock_inner_->on_focus_set();
-            }));
+            .WillByDefault(DoAll(
+                Assign(&has_focus_, true),
+                std::ref(mock_inner_->on_focus_set)));
 
         ON_CALL(*mock_inner_, do_has_focus())
-            .WillByDefault(Invoke([this]{return has_focus_;}));
+            .WillByDefault(ReturnPointee(&has_focus_));
     }
 
     bool has_focus_{false};
@@ -154,13 +145,12 @@ protected:
     a_framed_component_with_an_inner_component_that_has_focus()
     {
         ON_CALL(*mock_inner_, do_lose_focus())
-            .WillByDefault(Invoke([this]{
-                has_focus_ = false;
-                mock_inner_->on_focus_lost();
-            }));
+            .WillByDefault(DoAll(
+                Assign(&has_focus_, false),
+                std::ref(mock_inner_->on_focus_lost)));
 
         ON_CALL(*mock_inner_, do_has_focus())
-            .WillByDefault(Invoke([this]{return has_focus_;}));
+            .WillByDefault(ReturnPointee(&has_focus_));
     }
 
     bool has_focus_{true};

--- a/test/src/framed_component/framed_component_highlight_test.cpp
+++ b/test/src/framed_component/framed_component_highlight_test.cpp
@@ -4,7 +4,6 @@
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
 
-using testing::Invoke;
 using testing::Return;
 using testing::_;
 
@@ -58,7 +57,7 @@ protected:
             .WillByDefault(Return(terminalpp::extent{3, 3}));
 
         ON_CALL(*mock_frame_, do_draw(_, _))
-            .WillByDefault(Invoke(
+            .WillByDefault(
                 [this](auto &surface, auto const &region)
                 {
                     auto const &focus_element = terminalpp::element{
@@ -75,8 +74,7 @@ protected:
                         {
                             elem = focus_element;
                         });
-                }
-            ));
+                });
 
         framed_component_->set_size({3, 3});
     }

--- a/test/src/status_bar/status_bar_test.cpp
+++ b/test/src/status_bar/status_bar_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 using testing::_;
-using testing::Invoke;
 using testing::Return;
 
 TEST(a_status_bar, is_a_component)

--- a/test/src/viewport/viewport_cursor_test.cpp
+++ b/test/src/viewport/viewport_cursor_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-using testing::Invoke;
 using testing::Return;
 using testing::ValuesIn;
 using testing::_;

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using testing::Invoke;
 using testing::Return;
 using testing::ValuesIn;
 using testing::_;
@@ -141,7 +140,7 @@ TEST_F(a_viewport, with_an_offset_anchor_when_extended_southeast_reevaluates_anc
     fill_canvas(cvs, 'x');
 
     ON_CALL(*tracked_component_, do_draw(_, _))
-        .WillByDefault(Invoke(
+        .WillByDefault(
             [](munin::render_surface& surface, 
                terminalpp::rectangle const &region)
             {
@@ -155,7 +154,7 @@ TEST_F(a_viewport, with_an_offset_anchor_when_extended_southeast_reevaluates_anc
                         elem = ('a' + column + (row * 4));
                     });
             }
-        ));
+        );
     
     viewport_->set_position({0, 0});
     viewport_->set_size({1, 1});

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -9,7 +9,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-using testing::Invoke;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::SaveArg;
@@ -181,15 +180,11 @@ TEST_F(a_viewport, with_a_size_smaller_than_the_tracked_component_allows_the_tra
 
 TEST_F(a_viewport, forwards_events_to_the_tracked_component)
 {
-    std::string const test_event = "test event";
     boost::any received_event;
-    
     EXPECT_CALL(*tracked_component_, do_event(_))
-        .WillOnce(Invoke([&received_event](const boost::any& event)
-        {
-            received_event = event;
-        }));
+        .WillOnce(SaveArg<0>(&received_event));
 
+    std::string const test_event = "test event";
     viewport_->event(test_event);
     
     auto const *result = boost::any_cast<std::string>(&received_event);
@@ -350,7 +345,7 @@ TEST_F(a_viewport, draws_offset_area_when_viewport_position_is_offset)
     fill_canvas(cvs, 'x');
 
     ON_CALL(*tracked_component_, do_draw(_, _))
-        .WillByDefault(Invoke(
+        .WillByDefault(
             [](munin::render_surface& surface, 
                terminalpp::rectangle const &region)
             {
@@ -370,8 +365,7 @@ TEST_F(a_viewport, draws_offset_area_when_viewport_position_is_offset)
                     {
                         elem = ('a' + column + (row * 4));
                     });
-            }
-        ));
+            });
     
     viewport_->set_position({0, 0});
     viewport_->set_size({3, 2});
@@ -428,7 +422,7 @@ TEST_F(a_viewport, translates_mouse_events_to_the_tracked_component)
     boost::optional<terminalpp::mouse::event> received_mouse_event;
 
     ON_CALL(*tracked_component_, do_event(_))
-        .WillByDefault(Invoke(
+        .WillByDefault(
             [&received_mouse_event](boost::any const &ev)
             {
                 auto *mouse_event = 
@@ -438,8 +432,7 @@ TEST_F(a_viewport, translates_mouse_events_to_the_tracked_component)
                 {
                     received_mouse_event = *mouse_event;
                 }
-            }
-        ));
+            });
 
     viewport_->event(viewport_mouse_event);
 

--- a/test/src/viewport/viewport_test.hpp
+++ b/test/src/viewport/viewport_test.hpp
@@ -31,8 +31,8 @@ class viewport_mock_test_with_data
 protected:
     viewport_mock_test_with_data()
     {
-        using testing::Invoke;
         using testing::Return;
+        using testing::ReturnPointee;
         using testing::_;
         
         static auto constexpr tracked_component_preferred_size = terminalpp::extent{6, 6};
@@ -47,12 +47,14 @@ protected:
         // Mock the cursor position of the tracked component so that it does what it
         // is told and announces it to the viewport.
         ON_CALL(*tracked_component_, do_set_cursor_position(_))
-            .WillByDefault(Invoke([this](auto const &pos) { 
-                tracked_cursor_position_ = pos;
-                tracked_component_->on_cursor_position_changed();
-            }));
+            .WillByDefault(
+                [this](terminalpp::point const &pos)
+                {
+                    tracked_cursor_position_ = pos;
+                    tracked_component_->on_cursor_position_changed();
+                });
         ON_CALL(*tracked_component_, do_get_cursor_position())
-            .WillByDefault(Invoke([this] { return tracked_cursor_position_; }));
+            .WillByDefault(ReturnPointee(&tracked_cursor_position_));
 
         viewport_->set_size(viewport_size);
     }

--- a/test/src/window/window_json_test.cpp
+++ b/test/src/window/window_json_test.cpp
@@ -2,17 +2,16 @@
 #include <munin/window.hpp>
 #include <gtest/gtest.h>
 
-using testing::Invoke;
-
 TEST_F(a_window, reports_attributes_as_json)
 {
     EXPECT_CALL(*content_, do_to_json())
-        .WillOnce(Invoke([]() -> nlohmann::json
-        {
-            return {
-                { "type", "mock_content" }
-            };
-        }));
+        .WillOnce(
+            []() -> nlohmann::json
+            {
+                return {
+                    { "type", "mock_content" }
+                };
+            });
 
     nlohmann::json json = window_->to_json();
     ASSERT_EQ("window", json["type"]);

--- a/test/src/window/window_test.cpp
+++ b/test/src/window/window_test.cpp
@@ -1,8 +1,7 @@
 #include "window_test.hpp"
 #include <gtest/gtest.h>
 
-using testing::Invoke;
-using testing::Return;
+using testing::SaveArg;
 using testing::_;
 
 TEST_F(a_window, passes_events_to_the_content)
@@ -12,7 +11,7 @@ TEST_F(a_window, passes_events_to_the_content)
     boost::any result;
     
     EXPECT_CALL(*content_, do_event(_))
-        .WillOnce(Invoke([&result](boost::any const &event){ result = event; }));
+        .WillOnce(SaveArg<0>(&result));
     
     window_->event(tag{});
 


### PR DESCRIPTION
This involved either removing the Invoke and letting the lambda
or referenced function object do the work, or refactoring into
SaveArg/ReturnPointee pairs which describe the action work much
more declaratively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/225)
<!-- Reviewable:end -->
