### PR TITLE
Allow the caret of a text area to be set programatically.

### DIFF
--- a/include/munin/text_area.hpp
+++ b/include/munin/text_area.hpp
@@ -26,9 +26,14 @@ public:
     ~text_area() override;
 
     //* =====================================================================
-    /// \Brief Returns the position of the caret.
+    /// \brief Returns the position of the caret.
     //* =====================================================================
     text_index get_caret_position() const;
+
+    //* =====================================================================
+    /// \brief Sets the position of the caret.
+    //* =====================================================================
+    void set_caret_position(text_index position);
 
     //* =====================================================================
     /// \brief Returns the length of the document.

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -183,6 +183,14 @@ text_area::text_index text_area::get_caret_position() const
 }
 
 // ==========================================================================
+// SET_CARET_POSITION
+// ==========================================================================
+void text_area::set_caret_position(text_index position)
+{
+    pimpl_->set_caret_position(position);
+}
+
+// ==========================================================================
 // GET_LENGTH
 // ==========================================================================
 text_area::text_index text_area::get_length() const

--- a/test/src/text_area/text_area_test.cpp
+++ b/test/src/text_area/text_area_test.cpp
@@ -1,9 +1,9 @@
 #include "text_area_test.hpp"
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 
-terminalpp::element const a_text_area::fill = {'X'};
+terminalpp::element const a_text_area_base::fill = {'X'};
 
-void a_text_area::fill_canvas(terminalpp::extent canvas_size)
+void a_text_area_base::fill_canvas(terminalpp::extent canvas_size)
 {
     canvas_ = terminalpp::canvas{canvas_size};
     
@@ -18,7 +18,7 @@ void a_text_area::fill_canvas(terminalpp::extent canvas_size)
         });
 }
 
-void a_text_area::verify_oob_is_untouched()
+void a_text_area_base::verify_oob_is_untouched()
 {
     auto const in_bounds = text_area_.get_size();
     auto const out_of_bounds = canvas_.size();

--- a/test/src/text_area/text_area_test.hpp
+++ b/test/src/text_area/text_area_test.hpp
@@ -2,7 +2,7 @@
 #include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
-class a_text_area : public testing::Test
+class a_text_area_base
 {
 protected:
     static terminalpp::element const fill;
@@ -12,4 +12,8 @@ protected:
     
     void fill_canvas(terminalpp::extent canvas_size);
     void verify_oob_is_untouched();
+};
+
+class a_text_area : public a_text_area_base, public testing::Test
+{
 };


### PR DESCRIPTION
Closes #148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/226)
<!-- Reviewable:end -->
