### PR TITLE
Added handling of home and end to text area

### DIFF
--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -359,12 +359,16 @@ private:
                 set_cursor_position({
                     0, 
                     ev.modifiers == terminalpp::vk_modifier::ctrl
-                                  ? 0
-                                  : cursor_position_.y_});
+                  ? 0
+                  : cursor_position_.y_});
                 break;
 
             case terminalpp::vk::end:
-                set_cursor_position({width_, cursor_position_.y_});
+                set_cursor_position({
+                    width_, 
+                    ev.modifiers == terminalpp::vk_modifier::ctrl
+                  ? terminalpp::coordinate_type(laid_out_text_.size() - 1)
+                  : cursor_position_.y_});
                 break;
         }
     }

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -356,7 +356,11 @@ private:
                 break;
 
             case terminalpp::vk::home:
-                set_cursor_position({0, cursor_position_.y_});
+                set_cursor_position({
+                    0, 
+                    ev.modifiers == terminalpp::vk_modifier::ctrl
+                                  ? 0
+                                  : cursor_position_.y_});
                 break;
 
             case terminalpp::vk::end:

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -358,6 +358,10 @@ private:
             case terminalpp::vk::home:
                 set_cursor_position({0, cursor_position_.y_});
                 break;
+
+            case terminalpp::vk::end:
+                set_cursor_position({width_, cursor_position_.y_});
+                break;
         }
     }
 

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -354,6 +354,10 @@ private:
                     cursor_position_.x_,
                     std::max(cursor_position_.y_ + ev.repeat_count, 0)});
                 break;
+
+            case terminalpp::vk::home:
+                set_cursor_position({0, cursor_position_.y_});
+                break;
         }
     }
 

--- a/test/src/text_area/text_area_with_text_inserted_test.cpp
+++ b/test/src/text_area/text_area_with_text_inserted_test.cpp
@@ -487,6 +487,12 @@ static auto const keypress_home = terminalpp::virtual_key {
     1
 };
 
+static auto const keypress_end = terminalpp::virtual_key {
+    terminalpp::vk::end,
+    terminalpp::vk_modifier::none,
+    1
+};
+
 static movement_key_test_data const move_key_test_entries[] =
 {
     // Move the cursor left from various points
@@ -576,6 +582,15 @@ static movement_key_test_data const move_key_test_entries[] =
     movement_key_test_data{ {0,  1}, keypress_home,           {0,  1} },
     movement_key_test_data{ {10, 1}, keypress_home,           {0,  1} },
     movement_key_test_data{ {22, 1}, keypress_home,           {0,  1} },
+
+    // Move the cursor to the end
+    movement_key_test_data{ {0,  0}, keypress_end,            {27, 0} },
+    movement_key_test_data{ {10, 0}, keypress_end,            {27, 0} },
+    movement_key_test_data{ {27, 0}, keypress_end,            {27, 0} },
+
+    movement_key_test_data{ {0,  1}, keypress_end,            {22, 1} },
+    movement_key_test_data{ {10, 1}, keypress_end,            {22, 1} },
+    movement_key_test_data{ {22, 1}, keypress_end,            {22, 1} },
 };
 
 }

--- a/test/src/text_area/text_area_with_text_inserted_test.cpp
+++ b/test/src/text_area/text_area_with_text_inserted_test.cpp
@@ -481,6 +481,12 @@ static auto const keypress_cursor_down_n = terminalpp::virtual_key {
 static auto const keypress_cursor_down   = keypress_cursor_down_n<1>;
 static auto const keypress_cursor_down_2 = keypress_cursor_down_n<2>;
 
+static auto const keypress_home = terminalpp::virtual_key {
+    terminalpp::vk::home,
+    terminalpp::vk_modifier::none,
+    1
+};
+
 static movement_key_test_data const move_key_test_entries[] =
 {
     // Move the cursor left from various points
@@ -561,6 +567,15 @@ static movement_key_test_data const move_key_test_entries[] =
     movement_key_test_data{ {0,  1}, keypress_cursor_down_2,  {0,  3} },
     movement_key_test_data{ {15, 1}, keypress_cursor_down_2,  {15, 3} },
     movement_key_test_data{ {22, 1}, keypress_cursor_down_2,  {22, 3} },
+
+    // Move the cursor home
+    movement_key_test_data{ {0,  0}, keypress_home,           {0,  0} },
+    movement_key_test_data{ {10, 0}, keypress_home,           {0,  0} },
+    movement_key_test_data{ {27, 0}, keypress_home,           {0,  0} },
+
+    movement_key_test_data{ {0,  1}, keypress_home,           {0,  1} },
+    movement_key_test_data{ {10, 1}, keypress_home,           {0,  1} },
+    movement_key_test_data{ {22, 1}, keypress_home,           {0,  1} },
 };
 
 }

--- a/test/src/text_area/text_area_with_text_inserted_test.cpp
+++ b/test/src/text_area/text_area_with_text_inserted_test.cpp
@@ -487,6 +487,12 @@ static auto const keypress_home = terminalpp::virtual_key {
     1
 };
 
+static auto const keypress_ctrl_home = terminalpp::virtual_key {
+    terminalpp::vk::home,
+    terminalpp::vk_modifier::ctrl,
+    1
+};
+
 static auto const keypress_end = terminalpp::virtual_key {
     terminalpp::vk::end,
     terminalpp::vk_modifier::none,
@@ -582,6 +588,16 @@ static movement_key_test_data const move_key_test_entries[] =
     movement_key_test_data{ {0,  1}, keypress_home,           {0,  1} },
     movement_key_test_data{ {10, 1}, keypress_home,           {0,  1} },
     movement_key_test_data{ {22, 1}, keypress_home,           {0,  1} },
+
+    // Move the cursor to document home
+    movement_key_test_data{ {0,  0}, keypress_ctrl_home,      {0,  0} },
+    movement_key_test_data{ {10, 0}, keypress_ctrl_home,      {0,  0} },
+    movement_key_test_data{ {27, 0}, keypress_ctrl_home,      {0,  0} },
+
+    movement_key_test_data{ {0,  1}, keypress_ctrl_home,      {0,  0} },
+    movement_key_test_data{ {10, 1}, keypress_ctrl_home,      {0,  0} },
+    movement_key_test_data{ {22, 1}, keypress_ctrl_home,      {0,  0} },
+
 
     // Move the cursor to the end
     movement_key_test_data{ {0,  0}, keypress_end,            {27, 0} },

--- a/test/src/text_area/text_area_with_text_inserted_test.cpp
+++ b/test/src/text_area/text_area_with_text_inserted_test.cpp
@@ -499,6 +499,12 @@ static auto const keypress_end = terminalpp::virtual_key {
     1
 };
 
+static auto const keypress_ctrl_end = terminalpp::virtual_key {
+    terminalpp::vk::end,
+    terminalpp::vk_modifier::ctrl,
+    1
+};
+
 static movement_key_test_data const move_key_test_entries[] =
 {
     // Move the cursor left from various points
@@ -598,7 +604,6 @@ static movement_key_test_data const move_key_test_entries[] =
     movement_key_test_data{ {10, 1}, keypress_ctrl_home,      {0,  0} },
     movement_key_test_data{ {22, 1}, keypress_ctrl_home,      {0,  0} },
 
-
     // Move the cursor to the end
     movement_key_test_data{ {0,  0}, keypress_end,            {27, 0} },
     movement_key_test_data{ {10, 0}, keypress_end,            {27, 0} },
@@ -607,6 +612,15 @@ static movement_key_test_data const move_key_test_entries[] =
     movement_key_test_data{ {0,  1}, keypress_end,            {22, 1} },
     movement_key_test_data{ {10, 1}, keypress_end,            {22, 1} },
     movement_key_test_data{ {22, 1}, keypress_end,            {22, 1} },
+
+    // Move the cursor to document end
+    movement_key_test_data{ {0,  0}, keypress_ctrl_end,       {0,  6} },
+    movement_key_test_data{ {10, 0}, keypress_ctrl_end,       {0,  6} },
+    movement_key_test_data{ {27, 0}, keypress_ctrl_end,       {0,  6} },
+
+    movement_key_test_data{ {0,  1}, keypress_ctrl_end,       {0,  6} },
+    movement_key_test_data{ {10, 1}, keypress_ctrl_end,       {0,  6} },
+    movement_key_test_data{ {22, 1}, keypress_ctrl_end,       {0,  6} },
 };
 
 }


### PR DESCRIPTION
Includes home (line home), end (line end), ctrl-home (document home) and ctrl-end (document end).

Closes #231.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/232)
<!-- Reviewable:end -->
