### PR TITLE
Added handling of pgup and pgdn to viewports.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,7 @@ target_sources(munin_tester
         test/src/viewport/viewport_test.cpp
         test/src/viewport/viewport_resize_strategy_test.cpp
         test/src/viewport/viewport_cursor_test.cpp
+        test/src/viewport/viewport_keypress_test.cpp
         test/src/viewport/viewport_redraw_test.cpp
         test/src/viewport/viewport_size_test.cpp
         test/src/window/window_json_test.cpp

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -194,7 +194,10 @@ struct viewport::impl
                     cursor_position.y_ + viewport_height
                 });
             }
-            
+            else
+            {
+                tracked_component_->event(ev);
+            }
         }
         else
         {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1,6 +1,7 @@
 #include "munin/viewport.hpp"
 #include "munin/render_surface.hpp"
 #include <terminalpp/mouse.hpp>
+#include <terminalpp/virtual_key.hpp>
 #include <boost/algorithm/clamp.hpp>
 #include <boost/make_unique.hpp>
 #include <boost/range/adaptor/filtered.hpp>
@@ -157,6 +158,9 @@ struct viewport::impl
         auto const *mouse_event = 
             boost::any_cast<terminalpp::mouse::event>(&ev);
 
+        auto const *keypress_event =
+            boost::any_cast<terminalpp::virtual_key>(&ev);
+
         if (mouse_event != nullptr)
         {
             auto const translated_event = terminalpp::mouse::event {
@@ -165,6 +169,32 @@ struct viewport::impl
             };
 
             return tracked_component_->event(translated_event);
+        }
+        else if (keypress_event != nullptr)
+        {
+            if (keypress_event->key == terminalpp::vk::pgup)
+            {
+                auto const viewport_height = self_.get_size().height_;
+                auto const cursor_position =
+                    tracked_component_->get_cursor_position();
+                
+                tracked_component_->set_cursor_position({
+                    cursor_position.x_,
+                    cursor_position.y_ - viewport_height
+                });
+            }
+            else if (keypress_event->key == terminalpp::vk::pgdn)
+            {
+                auto const viewport_height = self_.get_size().height_;
+                auto const cursor_position = 
+                    tracked_component_->get_cursor_position();
+
+                tracked_component_->set_cursor_position({
+                    cursor_position.x_,
+                    cursor_position.y_ + viewport_height
+                });
+            }
+            
         }
         else
         {

--- a/test/src/viewport/viewport_keypress_test.cpp
+++ b/test/src/viewport/viewport_keypress_test.cpp
@@ -1,0 +1,57 @@
+#include "viewport_test.hpp"
+#include <terminalpp/virtual_key.hpp>
+#include <gtest/gtest.h>
+
+using testing::ReturnPointee;
+using testing::SaveArg;
+using testing::_;
+
+TEST_F(a_viewport, when_receiving_a_pgdn_translates_that_to_a_cursor_set)
+{
+    viewport_->set_size({3, 3});
+    tracked_component_->set_size({9, 9});
+
+    auto const keypress_pgdn = terminalpp::virtual_key {
+        terminalpp::vk::pgdn,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    terminalpp::point tracked_cursor_position = terminalpp::point{1, 1};
+    ON_CALL(*tracked_component_, do_get_cursor_position())
+        .WillByDefault(ReturnPointee(&tracked_cursor_position));
+    ON_CALL(*tracked_component_, do_set_cursor_position(_))
+        .WillByDefault(SaveArg<0>(&tracked_cursor_position));
+
+    viewport_->event(keypress_pgdn);
+
+    // The pgdn will have been translated to a cursor move down that
+    // relates to the height of the viewport.
+    auto const expected_cursor_position = terminalpp::point({1, 4});
+    ASSERT_EQ(expected_cursor_position, tracked_cursor_position);
+}
+
+TEST_F(a_viewport, when_receiving_a_pgup_translates_that_to_a_cursor_set)
+{
+    viewport_->set_size({3, 3});
+    tracked_component_->set_size({9, 9});
+
+    auto const keypress_pgup = terminalpp::virtual_key {
+        terminalpp::vk::pgup,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    terminalpp::point tracked_cursor_position = terminalpp::point{4, 4};
+    ON_CALL(*tracked_component_, do_get_cursor_position())
+        .WillByDefault(ReturnPointee(&tracked_cursor_position));
+    ON_CALL(*tracked_component_, do_set_cursor_position(_))
+        .WillByDefault(SaveArg<0>(&tracked_cursor_position));
+
+    viewport_->event(keypress_pgup);
+
+    // The pgdn will have been translated to a cursor move down that
+    // relates to the height of the viewport.
+    auto const expected_cursor_position = terminalpp::point({4, 1});
+    ASSERT_EQ(expected_cursor_position, tracked_cursor_position);
+}

--- a/test/src/viewport/viewport_test.cpp
+++ b/test/src/viewport/viewport_test.cpp
@@ -6,6 +6,7 @@
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <terminalpp/canvas.hpp>
 #include <terminalpp/mouse.hpp>
+#include <terminalpp/virtual_key.hpp>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -181,8 +182,8 @@ TEST_F(a_viewport, with_a_size_smaller_than_the_tracked_component_allows_the_tra
 TEST_F(a_viewport, forwards_events_to_the_tracked_component)
 {
     boost::any received_event;
-    EXPECT_CALL(*tracked_component_, do_event(_))
-        .WillOnce(SaveArg<0>(&received_event));
+    ON_CALL(*tracked_component_, do_event(_))
+        .WillByDefault(SaveArg<0>(&received_event));
 
     std::string const test_event = "test event";
     viewport_->event(test_event);
@@ -190,6 +191,26 @@ TEST_F(a_viewport, forwards_events_to_the_tracked_component)
     auto const *result = boost::any_cast<std::string>(&received_event);
     ASSERT_TRUE(result != nullptr);
     ASSERT_EQ(test_event, *result);
+}
+
+TEST_F(a_viewport, forwards_keypress_events_to_the_tracked_component)
+{
+    boost::any received_event;
+    ON_CALL(*tracked_component_, do_event(_))
+        .WillByDefault(SaveArg<0>(&received_event));
+        
+    auto const keypress_event = terminalpp::virtual_key {
+        terminalpp::vk::lowercase_a,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    viewport_->event(keypress_event);
+    
+    auto const *result = 
+        boost::any_cast<terminalpp::virtual_key>(&received_event);
+    ASSERT_TRUE(result != nullptr);
+    ASSERT_EQ(keypress_event, *result);
 }
 
 TEST_F(a_viewport, forwards_repaint_events_from_the_tracked_component)


### PR DESCRIPTION
These are converted to moves of the cursor of the tracked component
by exactly one screen's length.

Closes #233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/234)
<!-- Reviewable:end -->
