### PR TITLE
Windows now support injected render surface capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ target_sources(munin_tester
         test/src/viewport/viewport_size_test.cpp
         test/src/window/window_json_test.cpp
         test/src/window/window_test.cpp
+        test/src/window/window_render_capabilities_test.cpp
         test/src/window/window_repaint_test.cpp
 ) 
 

--- a/include/munin/render_surface_capabilities.hpp
+++ b/include/munin/render_surface_capabilities.hpp
@@ -17,4 +17,22 @@ struct render_surface_capabilities
     virtual bool supports_unicode() const = 0;
 };
 
+// ==========================================================================
+// DEFAULT RENDER SURFACE CAPABILITIES
+// ==========================================================================
+class default_render_surface_capabilities
+  : public render_surface_capabilities
+{
+public :
+    // ======================================================================
+    // SUPPORTS_UNICODE
+    // ======================================================================
+    bool supports_unicode() const override
+    {
+        return true;
+    }
+};
+
+extern default_render_surface_capabilities default_capabilities;
+
 }

--- a/include/munin/window.hpp
+++ b/include/munin/window.hpp
@@ -29,6 +29,16 @@ public :
     explicit window(std::shared_ptr<component> content);
     
     //* =====================================================================
+    /// \brief Constructor
+    /// \param content A component that this window displays.  May not be
+    ///        null.
+    /// \param capabilities the capabilities of the render surface.
+    //* =====================================================================
+    window(
+        std::shared_ptr<component> content,
+        render_surface_capabilities const &capabilities);
+
+    //* =====================================================================
     /// \brief Destructor
     //* =====================================================================
     ~window();
@@ -64,7 +74,7 @@ public :
             repaint_regions.swap(repaint_regions_);
         }
 
-        render_surface surface(cvs);
+        render_surface surface(cvs, capabilities_);
         for (auto const &region : repaint_regions)
         {
             content_->draw(surface, region);
@@ -93,6 +103,7 @@ private :
     std::shared_ptr<component> content_;
     std::vector<terminalpp::rectangle> repaint_regions_;
     terminalpp::screen screen_;
+    render_surface_capabilities const &capabilities_;
 };
 
 }

--- a/src/render_surface.cpp
+++ b/src/render_surface.cpp
@@ -1,27 +1,8 @@
 #include "munin/render_surface.hpp"
 
 namespace munin {
-namespace {
 
-// ==========================================================================
-// DEFAULT RENDER SURFACE CAPABILITIES
-// ==========================================================================
-class default_render_surface_capabilities
-  : public render_surface_capabilities
-{
-public :
-    // ======================================================================
-    // SUPPORTS_UNICODE
-    // ======================================================================
-    bool supports_unicode() const override
-    {
-        return true;
-    }
-};
-
-static default_render_surface_capabilities default_capabilities;
-
-}
+default_render_surface_capabilities default_capabilities;
 
 // ==========================================================================
 // COLUMN_PROXY::CONSTRUCTOR

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -9,7 +9,18 @@ namespace munin {
 // CONSTRUCTOR
 // ==========================================================================
 window::window(std::shared_ptr<component> content)
-  : content_(std::move(content))
+  : window(std::move(content), default_capabilities)
+{
+}
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+window::window(
+    std::shared_ptr<component> content,
+    render_surface_capabilities const &capabilities)
+  : content_(std::move(content)),
+    capabilities_(capabilities)
 {
     auto const &request_repaint = 
         [this](auto const &regions)

--- a/test/src/window/window_render_capabilities_test.cpp
+++ b/test/src/window/window_render_capabilities_test.cpp
@@ -1,0 +1,54 @@
+#include "mock/component.hpp"
+#include "mock/render_surface_capabilities.hpp"
+#include <munin/window.hpp>
+#include <boost/make_unique.hpp>
+#include <boost/optional.hpp>
+#include <gtest/gtest.h>
+
+using testing::Return;
+using testing::WithArg;
+using testing::_;
+
+namespace {
+
+class a_window_that_does_not_support_unicode
+  : public testing::Test
+{
+public:
+    a_window_that_does_not_support_unicode()
+    {
+        ON_CALL(capabilities_, supports_unicode())
+            .WillByDefault(Return(false));
+
+        window_ = boost::make_unique<munin::window>(
+            content_,
+            capabilities_);
+    }
+
+protected:
+    mock_render_surface_capabilities capabilities_;
+    std::shared_ptr<mock_component> content_ { make_mock_component() };
+
+    std::unique_ptr<munin::window> window_;
+};
+
+}
+
+TEST_F(a_window_that_does_not_support_unicode, passes_those_capabilities_to_components)
+{
+    boost::optional<bool> supports_unicode = boost::none;
+    ON_CALL(*content_, do_draw(_, _))
+        .WillByDefault(WithArg<0>(
+            [&supports_unicode](munin::render_surface &surface)
+            {
+                supports_unicode = surface.supports_unicode();
+            }));
+
+    terminalpp::canvas cvs({3, 3});
+    terminalpp::terminal terminal;
+
+    window_->repaint(cvs, terminal, [](terminalpp::bytes){});
+    
+    ASSERT_TRUE(supports_unicode.is_initialized());
+    ASSERT_FALSE(*supports_unicode);
+}


### PR DESCRIPTION
This enables a sequence where a terminal is constructed using a particular terminal type which, as detected, supports or does not support some feature (e.g. unicode), which is then queried while drawing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/238)
<!-- Reviewable:end -->
