### PR TITLE
Implemented typing in a text area

### DIFF
--- a/.ci/fetch_system_dependencies.sh
+++ b/.ci/fetch_system_dependencies.sh
@@ -37,9 +37,9 @@ fi
 
 # Install Terminal++ dependency
 if [ ! -f "$EXTERNAL_ROOT/include/terminalpp/version/hpp" ]; then
-    wget https://github.com/KazDragon/terminalpp/archive/v2.0.2.tar.gz;
-    tar -xzf v2.0.2.tar.gz;
-    cd terminalpp-2.0.2;
+    wget https://github.com/KazDragon/terminalpp/archive/v2.0.3.tar.gz;
+    tar -xzf v2.0.3.tar.gz;
+    cd terminalpp-2.0.3;
     cmake -DCMAKE_INSTALL_PREFIX="$EXTERNAL_ROOT" -DTERMINALPP_WITH_TESTS=False .;
     make -j2 && make install;
     cd ..;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
     # And of course, Munin is built atop the Terminal++ library, which
     # also requires fmt.
     find_package(fmt 5.3 CONFIG REQUIRED)
-    find_package(terminalpp 2.0.2 CONFIG REQUIRED)
+    find_package(terminalpp 2.0.3 CONFIG REQUIRED)
 
     # If we are building with tests, then we require the GTest library
     if (${MUNIN_WITH_TESTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ target_sources(munin_tester
         test/src/text_area/new_text_area_test.cpp
         test/src/text_area/text_area_test.cpp
         test/src/text_area/text_area_with_text_inserted_test.cpp
+        test/src/text_area/text_area_typing_test.cpp
         test/src/text_area/text_area_test.hpp
         test/src/titled_frame/titled_frame_json_test.cpp
         test/src/titled_frame/titled_frame_test.cpp

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -371,6 +371,19 @@ private:
                   : cursor_position_.y_});
                 break;
 
+            case terminalpp::vk::bs:
+                text_.erase(
+                    text_.begin() + caret_position_,
+                    text_.begin() + caret_position_ + 1);
+                set_caret_position(get_caret_position() - 1);
+
+                layout_text();
+                self_.on_redraw({{
+                    {0, cursor_position_.y_},
+                    {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
+                }});
+                break;
+
             default:
                 text_.insert(
                     text_.begin() + caret_position_,

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -374,16 +374,19 @@ private:
             case terminalpp::vk::del:
                 // Fall-through
             case terminalpp::vk::bs:
-                text_.erase(
-                    text_.begin() + caret_position_,
-                    text_.begin() + caret_position_ + 1);
-                set_caret_position(get_caret_position() - 1);
+                if (get_caret_position() != 0)
+                {
+                    text_.erase(
+                        text_.begin() + caret_position_,
+                        text_.begin() + caret_position_ + 1);
+                    set_caret_position(get_caret_position() - 1);
 
-                layout_text();
-                self_.on_redraw({{
-                    {0, cursor_position_.y_},
-                    {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
-                }});
+                    layout_text();
+                    self_.on_redraw({{
+                        {0, cursor_position_.y_},
+                        {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
+                    }});
+                }
                 break;
 
             default:

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -372,7 +372,10 @@ private:
                 break;
 
             default:
-                text_.insert(text_.end(), terminalpp::byte(ev.key));
+                text_.insert(
+                    text_.begin() + caret_position_,
+                    terminalpp::byte(ev.key));
+                ++caret_position_;
                 break;
         }
     }

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -370,6 +370,10 @@ private:
                   ? terminalpp::coordinate_type(laid_out_text_.size() - 1)
                   : cursor_position_.y_});
                 break;
+
+            default:
+                text_.insert(text_.end(), terminalpp::byte(ev.key));
+                break;
         }
     }
 

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -371,6 +371,8 @@ private:
                   : cursor_position_.y_});
                 break;
 
+            case terminalpp::vk::del:
+                // Fall-through
             case terminalpp::vk::bs:
                 text_.erase(
                     text_.begin() + caret_position_,

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -375,7 +375,13 @@ private:
                 text_.insert(
                     text_.begin() + caret_position_,
                     terminalpp::byte(ev.key));
-                ++caret_position_;
+                set_caret_position(get_caret_position() + 1);
+
+                layout_text();
+                self_.on_redraw({{
+                    {0, cursor_position_.y_},
+                    {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
+                }});
                 break;
         }
     }

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -329,6 +329,101 @@ private:
     }
 
     // ======================================================================
+    // HANDLE_CURSOR_LEFT
+    // ======================================================================
+    void handle_cursor_left(int repeat_count)
+    {
+        set_caret_position(caret_position_ - repeat_count);
+    }
+
+    // ======================================================================
+    // HANDLE_CURSOR_RIGHT
+    // ======================================================================
+    void handle_cursor_right(int repeat_count)
+    {
+        set_caret_position(caret_position_ + repeat_count);
+    }
+
+    // ======================================================================
+    // HANDLE_CURSOR_UP
+    // ======================================================================
+    void handle_cursor_up(int repeat_count)
+    {
+        set_cursor_position({
+            cursor_position_.x_,
+            std::max(cursor_position_.y_ - repeat_count, 0)});
+    }
+
+    // ======================================================================
+    // HANDLE_CURSOR_DOWN
+    // ======================================================================
+    void handle_cursor_down(int repeat_count)
+    {
+        set_cursor_position({
+            cursor_position_.x_,
+            std::max(cursor_position_.y_ + repeat_count, 0)});
+    }
+
+    // ======================================================================
+    // HANDLE_HOME
+    // ======================================================================
+    void handle_home(terminalpp::vk_modifier modifiers)
+    {
+        set_cursor_position({
+            0, 
+            modifiers == terminalpp::vk_modifier::ctrl
+          ? 0
+          : cursor_position_.y_});
+    }
+
+    // ======================================================================
+    // HANDLE_END
+    // ======================================================================
+    void handle_end(terminalpp::vk_modifier modifiers)
+    {
+        set_cursor_position({
+            width_, 
+            modifiers == terminalpp::vk_modifier::ctrl
+          ? terminalpp::coordinate_type(laid_out_text_.size() - 1)
+          : cursor_position_.y_});
+    }
+
+    // ======================================================================
+    // HANDLE_BACKSPACE
+    // ======================================================================
+    void handle_backspace()
+    {
+        if (caret_position_ != 0)
+        {
+            text_.erase(
+                text_.begin() + caret_position_,
+                text_.begin() + caret_position_ + 1);
+            set_caret_position(caret_position_ - 1);
+
+            layout_text();
+            self_.on_redraw({{
+                {0, cursor_position_.y_},
+                {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
+            }});
+        }
+    }
+
+    // ======================================================================
+    // HANDLE_TEXT
+    // ======================================================================
+    void handle_text(terminalpp::byte by)
+    {
+        text_.insert(text_.begin() + caret_position_, by);
+        set_caret_position(get_caret_position() + 1);
+
+        layout_text();
+        self_.on_redraw({{
+            {0, cursor_position_.y_},
+            {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
+        }});
+    }
+
+    // ======================================================================
     // HANDLE_KEYPRESS_EVENT
     // ======================================================================
     void handle_keypress_event(terminalpp::virtual_key const &ev)
@@ -336,70 +431,37 @@ private:
         switch (ev.key)
         {
             case terminalpp::vk::cursor_left:
-                set_caret_position(caret_position_ - ev.repeat_count);
+                handle_cursor_left(ev.repeat_count);
                 break;
                 
             case terminalpp::vk::cursor_right:
-                set_caret_position(caret_position_ + ev.repeat_count);
+                handle_cursor_right(ev.repeat_count);
                 break;
 
             case terminalpp::vk::cursor_up:
-                set_cursor_position({
-                    cursor_position_.x_,
-                    std::max(cursor_position_.y_ - ev.repeat_count, 0)});
+                handle_cursor_up(ev.repeat_count);
                 break;
 
             case terminalpp::vk::cursor_down:
-                set_cursor_position({
-                    cursor_position_.x_,
-                    std::max(cursor_position_.y_ + ev.repeat_count, 0)});
+                handle_cursor_down(ev.repeat_count);
                 break;
 
             case terminalpp::vk::home:
-                set_cursor_position({
-                    0, 
-                    ev.modifiers == terminalpp::vk_modifier::ctrl
-                  ? 0
-                  : cursor_position_.y_});
+                handle_home(ev.modifiers);
                 break;
 
             case terminalpp::vk::end:
-                set_cursor_position({
-                    width_, 
-                    ev.modifiers == terminalpp::vk_modifier::ctrl
-                  ? terminalpp::coordinate_type(laid_out_text_.size() - 1)
-                  : cursor_position_.y_});
+                handle_end(ev.modifiers);
                 break;
 
             case terminalpp::vk::del:
                 // Fall-through
             case terminalpp::vk::bs:
-                if (get_caret_position() != 0)
-                {
-                    text_.erase(
-                        text_.begin() + caret_position_,
-                        text_.begin() + caret_position_ + 1);
-                    set_caret_position(get_caret_position() - 1);
-
-                    layout_text();
-                    self_.on_redraw({{
-                        {0, cursor_position_.y_},
-                        {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
-                    }});
-                }
+                handle_backspace();
                 break;
 
             default:
-                text_.insert(
-                    text_.begin() + caret_position_,
-                    terminalpp::byte(ev.key));
-                set_caret_position(get_caret_position() + 1);
-
-                layout_text();
-                self_.on_redraw({{
-                    {0, cursor_position_.y_},
-                    {width_, terminalpp::coordinate_type(laid_out_text_.size() - cursor_position_.y_)}
-                }});
+                handle_text(terminalpp::byte(ev.key));
                 break;
         }
     }

--- a/src/text_area.cpp
+++ b/src/text_area.cpp
@@ -490,7 +490,7 @@ private:
     // ======================================================================
     void handle_keypress_event(terminalpp::virtual_key const &ev)
     {
-        if (is_control_key(ev.key))
+        if (terminalpp::is_control_key(ev.key))
         {
             handle_control_key(ev);
         }

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -1,4 +1,6 @@
 #include "text_area_test.hpp"
+#include <munin/render_surface.hpp>
+#include <terminalpp/canvas.hpp>
 #include <terminalpp/virtual_key.hpp>
 
 TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
@@ -47,3 +49,52 @@ TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
     }
 }
 
+TEST_F(a_text_area, requests_a_redraw_when_text_is_added_via_keypress)
+{
+    terminalpp::canvas cvs({3, 3});
+    munin::render_surface surface{cvs};
+
+    text_area_.on_redraw.connect(
+        [&surface, this](auto const &regions)
+        {
+            for (auto const &region : regions)
+            {
+                text_area_.draw(surface, region);
+            }
+        });
+
+    text_area_.set_size({3, 3});
+
+    auto const keypress_d = terminalpp::virtual_key {
+        terminalpp::vk::lowercase_d,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    text_area_.event(keypress_d);
+
+    ASSERT_EQ(terminalpp::element{'d'}, cvs[0][0]);
+}
+
+TEST_F(a_text_area, updates_the_cursor_position_when_text_is_added_via_keypress)
+{
+    auto cursor_position = terminalpp::point{};
+    text_area_.on_cursor_position_changed.connect(
+        [&cursor_position, this]()
+        {
+            cursor_position = text_area_.get_cursor_position();
+        });
+
+    text_area_.set_size({3, 3});
+
+    auto const keypress_e = terminalpp::virtual_key {
+        terminalpp::vk::uppercase_e,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    text_area_.event(keypress_e);
+
+    auto const expected_cursor_position = terminalpp::point{1, 0};
+    ASSERT_EQ(expected_cursor_position, cursor_position);
+}

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -111,12 +111,15 @@ TEST_P(a_text_area_receiving_keypresses, responds_in_the_specified_manner)
 
 static keypress_test_data const keypress_data[] = 
 {
-    { ""_ts,     {0, 0}, keypress_a,   "a"_ts,   {1, 0} },
-    { "a"_ts,    {1, 0}, keypress_b,   "aB"_ts,  {2, 0} },
-    { "aB"_ts,   {0, 0}, keypress_c,   "CaB"_ts, {1, 0} },
+    { ""_ts,     {0, 0}, keypress_a,   "a"_ts,    {1, 0} },
+    { "a"_ts,    {1, 0}, keypress_b,   "aB"_ts,   {2, 0} },
+    { "aB"_ts,   {0, 0}, keypress_c,   "CaB"_ts,  {1, 0} },
 
-    { "test"_ts, {4, 0}, keypress_bs,  "tes"_ts, {3, 0} },
-    { "test"_ts, {4, 0}, keypress_del, "tes"_ts, {3, 0} },
+    { "test"_ts, {4, 0}, keypress_bs,  "tes"_ts,  {3, 0} },
+    { "test"_ts, {4, 0}, keypress_del, "tes"_ts,  {3, 0} },
+
+    { "test"_ts, {0, 0}, keypress_bs,  "test"_ts, {0, 0} },
+    { "test"_ts, {0, 0}, keypress_del, "test"_ts, {0, 0} },
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -16,4 +16,34 @@ TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
 
         ASSERT_EQ(expected_text, text_area_.get_text());
     }
+
+    {
+        auto const keypress_b = terminalpp::virtual_key {
+            terminalpp::vk::uppercase_b,
+            terminalpp::vk_modifier::none,
+            1,
+        };
+
+        text_area_.event(keypress_b);
+
+        auto const expected_text = terminalpp::string("aB");
+
+        ASSERT_EQ(expected_text, text_area_.get_text());
+    }
+
+    {
+        auto const keypress_c = terminalpp::virtual_key {
+            terminalpp::vk::uppercase_c,
+            terminalpp::vk_modifier::none,
+            1,
+        };
+
+        text_area_.set_caret_position(0);
+        text_area_.event(keypress_c);
+
+        auto const expected_text = terminalpp::string("CaB");
+
+        ASSERT_EQ(expected_text, text_area_.get_text());
+    }
 }
+

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -3,6 +3,8 @@
 #include <terminalpp/canvas.hpp>
 #include <terminalpp/virtual_key.hpp>
 
+using namespace terminalpp::literals;
+
 TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
 {
     {
@@ -97,4 +99,45 @@ TEST_F(a_text_area, updates_the_cursor_position_when_text_is_added_via_keypress)
 
     auto const expected_cursor_position = terminalpp::point{1, 0};
     ASSERT_EQ(expected_cursor_position, cursor_position);
+}
+
+TEST_F(a_text_area, deletes_text_before_the_cursor_when_backspace_is_pressed)
+{
+    auto cvs = terminalpp::canvas({10, 3});
+    text_area_.set_size({10, 3});
+
+    text_area_.on_redraw.connect(
+        [&cvs, this](auto const &regions)
+        {
+            for (auto const &region : regions)
+            {
+                munin::render_surface surface{cvs};
+                text_area_.draw(surface, region);
+            }
+        });
+
+    auto cursor_position = terminalpp::point{};
+    text_area_.on_cursor_position_changed.connect(
+        [&cursor_position, this]()
+        {
+            cursor_position = text_area_.get_cursor_position();
+        });
+
+    text_area_.insert_text("test"_ts);
+    text_area_.set_caret_position(3);
+
+    auto const keypress_bs = terminalpp::virtual_key {
+        terminalpp::vk::bs,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    text_area_.event(keypress_bs);
+
+    EXPECT_EQ("tes"_ts, text_area_.get_text());
+    EXPECT_EQ(terminalpp::point(2, 0), cursor_position);
+    EXPECT_EQ(terminalpp::element('t'), cvs[0][0]);
+    EXPECT_EQ(terminalpp::element('e'), cvs[1][0]);
+    EXPECT_EQ(terminalpp::element('s'), cvs[2][0]);
+    EXPECT_EQ(terminalpp::element(' '), cvs[3][0]);
 }

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -1,0 +1,19 @@
+#include "text_area_test.hpp"
+#include <terminalpp/virtual_key.hpp>
+
+TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
+{
+    {
+        auto const keypress_a = terminalpp::virtual_key {
+            terminalpp::vk::lowercase_a,
+            terminalpp::vk_modifier::none,
+            1
+        };
+
+        text_area_.event(keypress_a);
+
+        auto const expected_text = terminalpp::string("a");
+
+        ASSERT_EQ(expected_text, text_area_.get_text());
+    }
+}

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -4,56 +4,68 @@
 #include <terminalpp/virtual_key.hpp>
 
 using namespace terminalpp::literals;
+using testing::ValuesIn;
 
-TEST_F(a_text_area, appends_typed_keys_at_the_cursor)
+using keypress_test_data = std::tuple<
+    terminalpp::string,      // inserted text
+    terminalpp::point,       // cursor position
+    terminalpp::virtual_key, // keypress
+    terminalpp::string,      // expected text
+    terminalpp::point        // expected cursor position
+>;
+
+namespace {
+
+class a_text_area_receiving_keypresses
+  : public a_text_area_base,
+    public testing::TestWithParam<keypress_test_data>
 {
-    {
-        auto const keypress_a = terminalpp::virtual_key {
-            terminalpp::vk::lowercase_a,
-            terminalpp::vk_modifier::none,
-            1
-        };
+};
 
-        text_area_.event(keypress_a);
+auto const keypress_a = terminalpp::virtual_key {
+    terminalpp::vk::lowercase_a,
+    terminalpp::vk_modifier::none,
+    1
+};
 
-        auto const expected_text = terminalpp::string("a");
+auto const keypress_b = terminalpp::virtual_key {
+    terminalpp::vk::uppercase_b,
+    terminalpp::vk_modifier::none,
+    1,
+};
 
-        ASSERT_EQ(expected_text, text_area_.get_text());
-    }
+auto const keypress_c = terminalpp::virtual_key {
+    terminalpp::vk::uppercase_c,
+    terminalpp::vk_modifier::none,
+    1,
+};
 
-    {
-        auto const keypress_b = terminalpp::virtual_key {
-            terminalpp::vk::uppercase_b,
-            terminalpp::vk_modifier::none,
-            1,
-        };
+auto const keypress_bs = terminalpp::virtual_key {
+    terminalpp::vk::bs,
+    terminalpp::vk_modifier::none,
+    1
+};
 
-        text_area_.event(keypress_b);
+auto const keypress_del = terminalpp::virtual_key {
+    terminalpp::vk::del,
+    terminalpp::vk_modifier::none,
+    1
+};
 
-        auto const expected_text = terminalpp::string("aB");
-
-        ASSERT_EQ(expected_text, text_area_.get_text());
-    }
-
-    {
-        auto const keypress_c = terminalpp::virtual_key {
-            terminalpp::vk::uppercase_c,
-            terminalpp::vk_modifier::none,
-            1,
-        };
-
-        text_area_.set_caret_position(0);
-        text_area_.event(keypress_c);
-
-        auto const expected_text = terminalpp::string("CaB");
-
-        ASSERT_EQ(expected_text, text_area_.get_text());
-    }
 }
 
-TEST_F(a_text_area, requests_a_redraw_when_text_is_added_via_keypress)
+TEST_P(a_text_area_receiving_keypresses, responds_in_the_specified_manner)
 {
-    terminalpp::canvas cvs({3, 3});
+    using std::get;
+
+    auto const &params = GetParam();
+    auto const &inserted_text = get<0>(params);
+    auto const &cursor_position = get<1>(params);
+    auto const &keypress = get<2>(params);
+    auto const &expected_text = get<3>(params);
+    auto const &expected_cursor_position = get<4>(params);
+
+    terminalpp::canvas cvs({10, 1});
     munin::render_surface surface{cvs};
 
     text_area_.on_redraw.connect(
@@ -65,120 +77,50 @@ TEST_F(a_text_area, requests_a_redraw_when_text_is_added_via_keypress)
             }
         });
 
-    text_area_.set_size({3, 3});
+    text_area_.set_size({10, 1});
+    text_area_.insert_text(inserted_text);
+    text_area_.set_cursor_position(cursor_position);
 
-    auto const keypress_d = terminalpp::virtual_key {
-        terminalpp::vk::lowercase_d,
-        terminalpp::vk_modifier::none,
-        1
-    };
-
-    text_area_.event(keypress_d);
-
-    ASSERT_EQ(terminalpp::element{'d'}, cvs[0][0]);
-}
-
-TEST_F(a_text_area, updates_the_cursor_position_when_text_is_added_via_keypress)
-{
-    auto cursor_position = terminalpp::point{};
+    auto resultant_cursor_position = cursor_position;
     text_area_.on_cursor_position_changed.connect(
-        [&cursor_position, this]()
+        [&resultant_cursor_position, this]
         {
-            cursor_position = text_area_.get_cursor_position();
+            resultant_cursor_position = text_area_.get_cursor_position();
         });
+        
+    text_area_.event(keypress);
+    
+    auto const &text = text_area_.get_text();
+    EXPECT_EQ(expected_text, text);
+    EXPECT_EQ(expected_cursor_position, resultant_cursor_position);
 
-    text_area_.set_size({3, 3});
-
-    auto const keypress_e = terminalpp::virtual_key {
-        terminalpp::vk::uppercase_e,
-        terminalpp::vk_modifier::none,
-        1
-    };
-
-    text_area_.event(keypress_e);
-
-    auto const expected_cursor_position = terminalpp::point{1, 0};
-    ASSERT_EQ(expected_cursor_position, cursor_position);
+    for (terminalpp::coordinate_type col = 0; col < cvs.size().width_; ++col)
+    {
+        if (col < text.size())
+        {
+            EXPECT_EQ(text[col], cvs[col][0]) 
+                << "at column " << col;
+        }
+        else
+        {
+            EXPECT_EQ(terminalpp::element{' '}, cvs[col][0]) 
+                << "at column " << col;
+        }
+    }
 }
 
-TEST_F(a_text_area, deletes_text_before_the_cursor_when_backspace_is_pressed)
+static keypress_test_data const keypress_data[] = 
 {
-    auto cvs = terminalpp::canvas({10, 3});
-    text_area_.set_size({10, 3});
+    { ""_ts,     {0, 0}, keypress_a,   "a"_ts,   {1, 0} },
+    { "a"_ts,    {1, 0}, keypress_b,   "aB"_ts,  {2, 0} },
+    { "aB"_ts,   {0, 0}, keypress_c,   "CaB"_ts, {1, 0} },
 
-    text_area_.on_redraw.connect(
-        [&cvs, this](auto const &regions)
-        {
-            for (auto const &region : regions)
-            {
-                munin::render_surface surface{cvs};
-                text_area_.draw(surface, region);
-            }
-        });
+    { "test"_ts, {4, 0}, keypress_bs,  "tes"_ts, {3, 0} },
+    { "test"_ts, {4, 0}, keypress_del, "tes"_ts, {3, 0} },
+};
 
-    auto cursor_position = terminalpp::point{};
-    text_area_.on_cursor_position_changed.connect(
-        [&cursor_position, this]()
-        {
-            cursor_position = text_area_.get_cursor_position();
-        });
-
-    text_area_.insert_text("test"_ts);
-    text_area_.set_caret_position(3);
-
-    auto const keypress_bs = terminalpp::virtual_key {
-        terminalpp::vk::bs,
-        terminalpp::vk_modifier::none,
-        1
-    };
-
-    text_area_.event(keypress_bs);
-
-    EXPECT_EQ("tes"_ts, text_area_.get_text());
-    EXPECT_EQ(terminalpp::point(2, 0), cursor_position);
-    EXPECT_EQ(terminalpp::element('t'), cvs[0][0]);
-    EXPECT_EQ(terminalpp::element('e'), cvs[1][0]);
-    EXPECT_EQ(terminalpp::element('s'), cvs[2][0]);
-    EXPECT_EQ(terminalpp::element(' '), cvs[3][0]);
-}
-
-TEST_F(a_text_area, deletes_text_before_the_cursor_when_del_is_pressed)
-{
-    auto cvs = terminalpp::canvas({10, 3});
-    text_area_.set_size({10, 3});
-
-    text_area_.on_redraw.connect(
-        [&cvs, this](auto const &regions)
-        {
-            for (auto const &region : regions)
-            {
-                munin::render_surface surface{cvs};
-                text_area_.draw(surface, region);
-            }
-        });
-
-    auto cursor_position = terminalpp::point{};
-    text_area_.on_cursor_position_changed.connect(
-        [&cursor_position, this]()
-        {
-            cursor_position = text_area_.get_cursor_position();
-        });
-
-    text_area_.insert_text("test"_ts);
-    text_area_.set_caret_position(3);
-
-    auto const keypress_del = terminalpp::virtual_key {
-        terminalpp::vk::del,
-        terminalpp::vk_modifier::none,
-        1
-    };
-
-    text_area_.event(keypress_del);
-
-    EXPECT_EQ("tes"_ts, text_area_.get_text());
-    EXPECT_EQ(terminalpp::point(2, 0), cursor_position);
-    EXPECT_EQ(terminalpp::element('t'), cvs[0][0]);
-    EXPECT_EQ(terminalpp::element('e'), cvs[1][0]);
-    EXPECT_EQ(terminalpp::element('s'), cvs[2][0]);
-    EXPECT_EQ(terminalpp::element(' '), cvs[3][0]);
-}
+INSTANTIATE_TEST_SUITE_P(
+    text_areas_handle_keypresses,
+    a_text_area_receiving_keypresses,
+    ValuesIn(keypress_data)
+);

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -141,3 +141,44 @@ TEST_F(a_text_area, deletes_text_before_the_cursor_when_backspace_is_pressed)
     EXPECT_EQ(terminalpp::element('s'), cvs[2][0]);
     EXPECT_EQ(terminalpp::element(' '), cvs[3][0]);
 }
+
+TEST_F(a_text_area, deletes_text_before_the_cursor_when_del_is_pressed)
+{
+    auto cvs = terminalpp::canvas({10, 3});
+    text_area_.set_size({10, 3});
+
+    text_area_.on_redraw.connect(
+        [&cvs, this](auto const &regions)
+        {
+            for (auto const &region : regions)
+            {
+                munin::render_surface surface{cvs};
+                text_area_.draw(surface, region);
+            }
+        });
+
+    auto cursor_position = terminalpp::point{};
+    text_area_.on_cursor_position_changed.connect(
+        [&cursor_position, this]()
+        {
+            cursor_position = text_area_.get_cursor_position();
+        });
+
+    text_area_.insert_text("test"_ts);
+    text_area_.set_caret_position(3);
+
+    auto const keypress_del = terminalpp::virtual_key {
+        terminalpp::vk::del,
+        terminalpp::vk_modifier::none,
+        1
+    };
+
+    text_area_.event(keypress_del);
+
+    EXPECT_EQ("tes"_ts, text_area_.get_text());
+    EXPECT_EQ(terminalpp::point(2, 0), cursor_position);
+    EXPECT_EQ(terminalpp::element('t'), cvs[0][0]);
+    EXPECT_EQ(terminalpp::element('e'), cvs[1][0]);
+    EXPECT_EQ(terminalpp::element('s'), cvs[2][0]);
+    EXPECT_EQ(terminalpp::element(' '), cvs[3][0]);
+}


### PR DESCRIPTION
Typing in a text area now adds (or removes, for backspace/del) text for the keypress.

Closes #147

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/munin/239)
<!-- Reviewable:end -->
