### PR TITLE
refactor tests involving canvases

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   cppcoreguidelines-special-member-functions,
   -google-readability-todo,
   -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
   -modernize-avoid-c-arrays,
   -modernize-use-trailing-return-type,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ target_sources(munin_tester
         test/include/mock/animator.hpp
         test/include/mock/component.hpp
         test/include/mock/layout.hpp
+        test/src/assert_similar.cpp
         test/src/fill_canvas.cpp
         test/src/redraw.cpp
         test/src/mock/animator.cpp

--- a/include/munin/component.hpp
+++ b/include/munin/component.hpp
@@ -120,6 +120,19 @@ class MUNIN_EXPORT component
   /// \brief Draws the component.
   ///
   /// \param surface the surface on which the component should draw itself.
+  /// \par
+  /// Draws the whole component, as if
+  /// \code
+  /// component.draw(surface, {{}, component.size()});
+  /// \endcode
+  /// had been called.
+  //* =====================================================================
+  void draw(render_surface &surface) const;
+
+  //* =====================================================================
+  /// \brief Draws the component.
+  ///
+  /// \param surface the surface on which the component should draw itself.
   /// \param region the region relative to this component's origin that
   /// should be drawn.
   //* =====================================================================

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -1,4 +1,5 @@
 #include "munin/component.hpp"
+#include "munin/render_surface.hpp"
 #include <cassert>
 
 namespace munin {
@@ -107,6 +108,14 @@ terminalpp::point component::get_cursor_position() const
 void component::set_cursor_position(terminalpp::point const &position)
 {
   do_set_cursor_position(position);
+}
+
+// ==========================================================================
+// DRAW
+// ==========================================================================
+void component::draw(render_surface &surface) const
+{
+  draw(surface, {{}, get_size()});
 }
 
 // ==========================================================================

--- a/test/include/assert_similar.hpp
+++ b/test/include/assert_similar.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <terminalpp/canvas.hpp>
+#include <terminalpp/rectangle.hpp>
+#include <terminalpp/string.hpp>
+#include <gsl/gsl-lite.hpp>
+#include <gtest/gtest.h>
+
+void assert_similar_canvas_block(
+    std::initializer_list<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs);
+
+void assert_similar_canvas_block(
+    std::initializer_list<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs,
+    terminalpp::rectangle const &bounds);
+
+void assert_similar_canvas_block(
+    gsl::span<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs);
+
+void assert_similar_canvas_block(
+    gsl::span<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs,
+    terminalpp::rectangle const &bounds);

--- a/test/include/redraw.hpp
+++ b/test/include/redraw.hpp
@@ -1,7 +1,30 @@
 #pragma once
 
+#include <munin/render_surface.hpp>
+#include <terminalpp/canvas.hpp>
 #include <terminalpp/rectangle.hpp>
+#include <boost/range/algorithm_ext/insert.hpp>
 #include <vector>
+
+template <typename Component>
+auto redraw_component_on_surface(
+    Component &component, munin::render_surface &surface)
+{
+  return [&surface, &component](auto const &regions)
+  {
+    for (auto const &region : regions)
+    {
+      component.draw(surface, region);
+    }
+  };
+}
+
+template <typename Container>
+auto append_regions_to_container(Container &container)
+{
+  return [&container](auto const &regions)
+  { boost::insert(container, container.end(), regions); };
+}
 
 void assert_equivalent_redraw_regions(
     std::vector<terminalpp::rectangle> const &lhs,

--- a/test/src/assert_similar.cpp
+++ b/test/src/assert_similar.cpp
@@ -1,0 +1,42 @@
+#include "assert_similar.hpp"
+#include <terminalpp/algorithm/for_each_in_region.hpp>
+#include <gtest/gtest.h>
+
+void assert_similar_canvas_block(
+    std::initializer_list<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs)
+{
+  assert_similar_canvas_block(gsl::span{expected}, cvs);
+}
+
+void assert_similar_canvas_block(
+    gsl::span<terminalpp::string const> expected, terminalpp::canvas const &cvs)
+{
+  assert_similar_canvas_block(expected, cvs, {{}, cvs.size()});
+}
+
+void assert_similar_canvas_block(
+    std::initializer_list<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs,
+    terminalpp::rectangle const &bounds)
+{
+  assert_similar_canvas_block(gsl::span{expected}, cvs, bounds);
+}
+
+void assert_similar_canvas_block(
+    gsl::span<terminalpp::string const> expected,
+    terminalpp::canvas const &cvs,
+    terminalpp::rectangle const &bounds)
+{
+  terminalpp::for_each_in_region(
+      cvs,
+      bounds,
+      [&expected](
+          terminalpp::element const &elem,
+          terminalpp::coordinate_type column,
+          terminalpp::coordinate_type row)
+      {
+        ASSERT_EQ(expected[row][column], elem)
+            << "row = " << row << ", column = " << column;
+      });
+}

--- a/test/src/brush/brush_redraw_test.cpp
+++ b/test/src/brush/brush_redraw_test.cpp
@@ -1,5 +1,8 @@
+#include "redraw.hpp"
 #include <munin/brush.hpp>
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using testing::ElementsAreArray;
 
 TEST(a_brush_to_be_redrawn, redraws_entire_brush_when_setting_pattern)
 {
@@ -8,16 +11,11 @@ TEST(a_brush_to_be_redrawn, redraws_entire_brush_when_setting_pattern)
 
   int redraw_called = 0;
   std::vector<terminalpp::rectangle> redraw_regions;
-  brush.on_redraw.connect(
-      [&redraw_called, &redraw_regions](auto const &regions)
-      {
-        ++redraw_called;
-        redraw_regions = regions;
-      });
+  brush.on_redraw.connect(append_regions_to_container(redraw_regions));
 
   brush.set_pattern("test");
 
-  ASSERT_EQ(1, redraw_called);
-  ASSERT_EQ(1u, redraw_regions.size());
-  ASSERT_EQ(terminalpp::rectangle({0, 0}, {6, 3}), redraw_regions[0]);
+  ASSERT_THAT(
+      redraw_regions,
+      ElementsAreArray({terminalpp::rectangle{{0, 0}, {6, 3}}}));
 }

--- a/test/src/brush/brush_test.cpp
+++ b/test/src/brush/brush_test.cpp
@@ -1,12 +1,15 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/brush.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <terminalpp/canvas.hpp>
 #include <gtest/gtest.h>
 
+using namespace terminalpp::literals;  // NOLINT
+
 TEST(a_brush_with_its_pattern_set_empty, draws_whitespace_on_the_canvas)
 {
-  using namespace terminalpp::literals;
   munin::brush brush("abc"_ts);
 
   int called = 0;
@@ -20,103 +23,61 @@ TEST(a_brush_with_its_pattern_set_empty, draws_whitespace_on_the_canvas)
   brush.set_size({2, 2});
 
   terminalpp::canvas canvas({3, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface cv{canvas};
   brush.draw(cv, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "  X"_ts,
+      "  X"_ts,
+      "XXX"_ts
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_brush_with_its_pattern_set_to_a_single_line_pattern,
     draws_that_pattern_repeatedly)
 {
-  using namespace terminalpp::literals;
-
   munin::brush brush;
 
   int called = 0;
   auto on_preferred_size_changed = [&called] { ++called; };
   brush.on_preferred_size_changed.connect(on_preferred_size_changed);
 
-  terminalpp::string const pattern = "abc"_ts;
-  brush.set_pattern(pattern);
+  brush.set_pattern("abc"_ts);
 
   ASSERT_EQ(1, called);
 
   brush.set_size({6, 2});
 
   terminalpp::canvas canvas({8, 4});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface cv{canvas};
   cv.offset_by({1, 1});
   brush.draw(cv, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[6][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][0]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[6][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][1]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[5][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[6][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][2]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[6][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "XXXXXXXX"_ts,
+      "XabcabcX"_ts,
+      "XabcabcX"_ts,
+      "XXXXXXXX"_ts
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_brush_with_its_pattern_set_to_a_multi_line_pattern,
     draws_that_pattern_repeatedly)
 {
-  using namespace terminalpp::literals;
-
   munin::brush brush;
 
   int called = 0;
@@ -132,57 +93,22 @@ TEST(
   brush.set_size({4, 4});
 
   terminalpp::canvas canvas({6, 6});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface cv{canvas};
   cv.offset_by({1, 1});
-  brush.draw(cv, {{}, brush.get_size()});
+  brush.draw({cv}, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][0]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][1]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][2]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[4][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][3]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][4]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[1][4]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[2][4]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][4]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[4][4]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][4]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][5]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "XXXXXX"_ts,
+      "XababX"_ts,
+      "XcdcdX"_ts,
+      "XababX"_ts,
+      "XcdcdX"_ts,
+      "XXXXXX"_ts
+          // clang-format on
+      },
+      canvas);
 }

--- a/test/src/brush/new_brush_test.cpp
+++ b/test/src/brush/new_brush_test.cpp
@@ -1,7 +1,11 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/brush.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;  // NOLINT
 
 TEST(a_new_brush, has_a_singular_preferred_size)
 {
@@ -13,12 +17,11 @@ TEST(
     a_new_brush_with_a_single_line_pattern,
     has_a_preferred_size_with_the_width_of_that_line)
 {
-  using namespace terminalpp::literals;
-  auto const pattern = "abcde"_ts;
+  static auto const pattern = "abcde"_ts;
   munin::brush brush(pattern);
 
-  auto const expected_preferred_size =
-      terminalpp::extent{terminalpp::coordinate_type(pattern.size()), 1};
+  static auto const expected_preferred_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(pattern.size()), 1};
 
   ASSERT_EQ(expected_preferred_size, brush.get_preferred_size());
 }
@@ -27,14 +30,13 @@ TEST(
     a_new_brush_with_a_multi_line_pattern,
     has_a_preferred_size_with_the_width_of_the_longest_line_and_height_of_the_number_of_lines)
 {
-  using namespace terminalpp::literals;
-  auto const pattern =
+  static auto const pattern =
       std::vector<terminalpp::string>{"abcde"_ts, "abcdefg"_ts};
 
   munin::brush brush(pattern);
 
-  auto const expected_preferred_size =
-      terminalpp::extent{terminalpp::coordinate_type(pattern[1].size()), 2};
+  static auto const expected_preferred_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(pattern[1].size()), 2};
 
   ASSERT_EQ(expected_preferred_size, brush.get_preferred_size());
 }
@@ -45,26 +47,20 @@ TEST(a_new_brush, draws_whitespace_on_the_canvas)
   brush.set_size({2, 2});
 
   terminalpp::canvas canvas({3, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   brush.draw(surface, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "  X"_ts,
+      "  X"_ts,
+      "XXX"_ts
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_brush, refuses_focus)
@@ -76,124 +72,54 @@ TEST(a_new_brush, refuses_focus)
 
 TEST(a_new_brush_with_a_single_line_pattern, draws_that_pattern_repeatedly)
 {
-  using namespace terminalpp::literals;
-  terminalpp::string pattern = "abc"_ts;
-
-  munin::brush brush(pattern);
+  munin::brush brush("abc"_ts);
   brush.set_size({6, 2});
 
   terminalpp::canvas canvas({8, 4});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   surface.offset_by({1, 1});
   brush.draw(surface, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[6][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][0]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[6][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][1]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[5][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[6][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][2]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[6][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[7][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "XXXXXXXX"_ts,
+      "XabcabcX"_ts,
+      "XabcabcX"_ts,
+      "XXXXXXXX"_ts
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_brush_with_a_multi_line_pattern, draws_that_pattern_repeatedly)
 {
-  using namespace terminalpp::literals;
   std::vector<terminalpp::string> pattern = {"ab"_ts, "cd"_ts};
 
   munin::brush brush(pattern);
   brush.set_size({4, 4});
 
   terminalpp::canvas canvas({6, 6});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   surface.offset_by({1, 1});
   brush.draw(surface, {{}, brush.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][0]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][1]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][2]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[4][3]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][3]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][4]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[1][4]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[2][4]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][4]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[4][4]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][4]);
-
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[3][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[4][5]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[5][5]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+      "XXXXXX"_ts,
+      "XababX"_ts,
+      "XcdcdX"_ts,
+      "XababX"_ts,
+      "XcdcdX"_ts,
+      "XXXXXX"_ts
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(make_brush_with_no_pattern, makes_a_new_default_brush)
@@ -204,7 +130,6 @@ TEST(make_brush_with_no_pattern, makes_a_new_default_brush)
 
 TEST(make_brush_with_a_string_pattern, makes_a_single_line_brush)
 {
-  using namespace terminalpp::literals;
   std::shared_ptr<munin::brush> brush = munin::make_brush("test"_ts);
   ASSERT_EQ(terminalpp::extent(4, 1), brush->get_preferred_size());
 }

--- a/test/src/button/button_test.cpp
+++ b/test/src/button/button_test.cpp
@@ -1,3 +1,5 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/button.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/canvas.hpp>
@@ -5,39 +7,64 @@
 #include <terminalpp/virtual_key.hpp>
 #include <gtest/gtest.h>
 
+using namespace terminalpp::literals;  // NOLINT
 using testing::ValuesIn;
 
 TEST(a_new_button, can_be_constructed_from_a_string)
 {
-  auto const size = terminalpp::extent{6, 3};
+  static auto const button_size = terminalpp::extent{6, 3};
+  static auto const canvas_size = terminalpp::extent{8, 5};
 
   auto button = munin::make_button(" OK ");
-  button->set_size(size);
+  button->set_size(button_size);
 
-  terminalpp::canvas canvas(size);
+  terminalpp::canvas canvas(canvas_size);
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface(canvas);
+  surface.offset_by({1, 1});
+  button->draw(surface);
 
-  button->draw(surface, {{}, size});
-
-  ASSERT_EQ('O', canvas[2][1]);
-  ASSERT_EQ('K', canvas[3][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          R"(XXXXXXXX)"_ts,
+          R"(X\U256D\U2500\U2500\U2500\U2500\U256EX)"_ets,
+          R"(X\U2502 OK \U2502X)"_ets,
+          R"(X\U2570\U2500\U2500\U2500\U2500\U256FX)"_ets,
+          R"(XXXXXXXX)"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_button, can_be_constructed_from_a_terminal_string)
 {
-  auto const size = terminalpp::extent{8, 3};
+  auto const button_size = terminalpp::extent{8, 3};
+  auto const canvas_size = terminalpp::extent{10, 5};
 
-  using namespace terminalpp::literals;
   auto button = munin::make_button("CANCEL"_ts);
-  button->set_size(size);
+  button->set_size(button_size);
 
-  terminalpp::canvas canvas(size);
+  terminalpp::canvas canvas(canvas_size);
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface(canvas);
+  surface.offset_by({1, 1});
 
-  button->draw(surface, {{}, size});
+  button->draw(surface);
 
-  ASSERT_EQ('A', canvas[2][1]);
-  ASSERT_EQ('E', canvas[5][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          R"(XXXXXXXXXX)"_ts,
+          R"(X\U256D\U2500\U2500\U2500\U2500\U2500\U2500\U256EX)"_ets,
+          R"(X\U2502CANCEL\U2502X)"_ets,
+          R"(X\U2570\U2500\U2500\U2500\U2500\U2500\U2500\U256FX)"_ets,
+          R"(XXXXXXXXXX)"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_button, can_receive_focus)

--- a/test/src/container/container_test.hpp
+++ b/test/src/container/container_test.hpp
@@ -24,7 +24,7 @@ class container_test_base : public testing::Test
     container.on_redraw.connect([this](auto const &) { ++redraw_count; });
   }
 
-  void ResetCounters()
+  void reset_counters()
   {
     preferred_size_changed_count = 0;
     focus_set_count = 0;
@@ -59,7 +59,7 @@ class a_container_with_one_component : public a_container
   {
     container.add_component(component);
 
-    ResetCounters();
+    reset_counters();
   }
 
   std::shared_ptr<mock_component> component{make_mock_component()};
@@ -83,7 +83,7 @@ class a_container_with_one_component_that_has_focus
     container.set_focus();
 
     assert(container.has_focus());
-    ResetCounters();
+    reset_counters();
   }
 };
 
@@ -119,7 +119,7 @@ class a_container_with_two_components_where_the_first_has_focus
     container.focus_next();
 
     assert(container.has_focus());
-    ResetCounters();
+    reset_counters();
   }
 };
 
@@ -142,7 +142,7 @@ class a_container_with_two_components_where_the_last_has_focus
     container.focus_previous();
 
     assert(container.has_focus());
-    ResetCounters();
+    reset_counters();
   }
 };
 
@@ -176,7 +176,7 @@ class a_container_with_three_components_where_the_first_has_focus
     container.focus_next();
 
     assert(container.has_focus());
-    ResetCounters();
+    reset_counters();
   }
 };
 
@@ -199,7 +199,7 @@ class a_container_with_three_components_where_the_last_has_focus
     container.focus_previous();
 
     assert(container.has_focus());
-    ResetCounters();
+    reset_counters();
   }
 };
 

--- a/test/src/edit/edit_mouse_test.cpp
+++ b/test/src/edit/edit_mouse_test.cpp
@@ -1,4 +1,5 @@
 #include "fill_canvas.hpp"
+#include "redraw.hpp"
 #include <munin/edit.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
@@ -31,14 +32,7 @@ class mouse_click_test : public testing::TestWithParam<mouse_test_data>
     fill_canvas(cvs_, 'x');
     surface_.offset_by({1, 1});
 
-    edit_.on_redraw.connect(
-        [this](auto const &regions)
-        {
-          for (auto const &region : regions)
-          {
-            edit_.draw(surface_, region);
-          }
-        });
+    edit_.on_redraw.connect(redraw_component_on_surface(edit_, surface_));
 
     edit_.set_position({0, 0});
     edit_.set_size({4, 1});

--- a/test/src/edit/edit_with_content_test.cpp
+++ b/test/src/edit/edit_with_content_test.cpp
@@ -1,4 +1,5 @@
 #include "fill_canvas.hpp"
+#include "redraw.hpp"
 #include <munin/edit.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
@@ -27,14 +28,7 @@ class keypress_test : public testing::TestWithParam<keypress_data>
     fill_canvas(cvs_, 'x');
     surface_.offset_by({1, 1});
 
-    edit_.on_redraw.connect(
-        [this](auto const &regions)
-        {
-          for (auto const &region : regions)
-          {
-            edit_.draw(surface_, region);
-          }
-        });
+    edit_.on_redraw.connect(redraw_component_on_surface(edit_, surface_));
 
     edit_.set_position({0, 0});
     edit_.set_size({4, 1});

--- a/test/src/filled_box/filled_box_test.cpp
+++ b/test/src/filled_box/filled_box_test.cpp
@@ -1,6 +1,9 @@
+#include "assert_similar.hpp"
 #include <munin/filled_box.hpp>
 #include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;  // NOLINT
 
 TEST(make_fill, makes_a_new_filled_box)
 {
@@ -31,10 +34,14 @@ TEST(a_filled_box, draws_its_fill)
 
   filled_box.draw(surface, {{}, {1, 1}});
 
-  ASSERT_EQ(terminalpp::element('Y'), canvas[0][0]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[1][0]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[1][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "Y "_ts,
+          "  "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_filled_box, draws_only_within_given_region)
@@ -48,18 +55,16 @@ TEST(a_filled_box, draws_only_within_given_region)
 
   filled_box.draw(surface, {{}, {1, 2}});
 
-  ASSERT_EQ(terminalpp::element(' '), canvas[0][0]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[1][0]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[2][0]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element('Y'), canvas[1][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[2][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[0][2]);
-  ASSERT_EQ(terminalpp::element('Y'), canvas[1][2]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[2][2]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[0][3]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[1][3]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[2][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "   "_ts,
+          " Y "_ts,
+          " Y "_ts,
+          "   "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_filled_box, reports_attributes_as_json)

--- a/test/src/filled_box/functional_filled_box_test.cpp
+++ b/test/src/filled_box/functional_filled_box_test.cpp
@@ -1,6 +1,9 @@
+#include "assert_similar.hpp"
 #include <munin/filled_box.hpp>
 #include <munin/render_surface.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;  // NOLINT
 
 TEST(a_filled_box, can_retrieve_its_fill_from_a_function)
 {
@@ -16,17 +19,25 @@ TEST(a_filled_box, can_retrieve_its_fill_from_a_function)
 
   box->draw(surface, terminalpp::rectangle{{}, {2, 2}});
 
-  ASSERT_EQ('x', canvas[0][0]);
-  ASSERT_EQ('x', canvas[0][1]);
-  ASSERT_EQ('x', canvas[1][0]);
-  ASSERT_EQ('x', canvas[1][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xx"_ts,
+          "xx"_ts,
+          // clang-format on
+      },
+      canvas);
 
   fill = 'y';
 
   box->draw(surface, terminalpp::rectangle{{}, {2, 2}});
 
-  ASSERT_EQ('y', canvas[0][0]);
-  ASSERT_EQ('y', canvas[0][1]);
-  ASSERT_EQ('y', canvas[1][0]);
-  ASSERT_EQ('y', canvas[1][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "yy"_ts,
+          "yy"_ts,
+          // clang-format on
+      },
+      canvas);
 }

--- a/test/src/filled_box/new_filled_box_test.cpp
+++ b/test/src/filled_box/new_filled_box_test.cpp
@@ -1,7 +1,11 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/filled_box.hpp>
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;  // NOLINT
 
 TEST(a_new_filled_box, has_a_singular_preferred_size)
 {
@@ -15,26 +19,21 @@ TEST(a_new_filled_box, draws_whitespace_on_the_canvas)
   filled_box.set_size({2, 2});
 
   terminalpp::canvas canvas({3, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
+  surface.offset_by({1, 1});
   filled_box.draw(surface, {{}, filled_box.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "XXX"_ts,
+          "X  "_ts,
+          "X  "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_filled_box, refuses_focus)

--- a/test/src/image/image_test.cpp
+++ b/test/src/image/image_test.cpp
@@ -1,91 +1,61 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/image.hpp>
 #include <munin/render_surface.hpp>
-#include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;  // NOLINT
 
 TEST(an_image_with_its_content_set_empty, draws_fill_on_the_canvas)
 {
-  using namespace terminalpp::literals;
   munin::image image("test"_ts, ' ');
 
   image.set_content();
 
   image.set_size({6, 3});
   terminalpp::canvas canvas({6, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "      "_ts,
+          "      "_ts,
+          "      "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(an_image_with_its_content_set_to_single_line, draws_line_on_the_canvas)
 {
-  using namespace terminalpp::literals;
   munin::image image(' ');
   image.set_size({6, 3});
 
   image.set_content("test"_ts);
 
   terminalpp::canvas canvas({6, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'e'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'s'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "      "_ts,
+          " test "_ts,
+          "      "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(an_image_with_its_content_set_to_multi_line, draws_lines_on_the_canvas)
 {
-  using namespace terminalpp::literals;
   munin::image image(' ');
   image.set_size({6, 4});
 
@@ -94,41 +64,21 @@ TEST(an_image_with_its_content_set_to_multi_line, draws_lines_on_the_canvas)
   image.set_content(content);
 
   terminalpp::canvas canvas({6, 4});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'e'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'s'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[5][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "      "_ts,
+          " test "_ts,
+          " abcd "_ts,
+          "      "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(an_image, sets_its_content_empty_when_set_to_an_empty_string)
@@ -141,21 +91,18 @@ TEST(an_image, sets_its_content_empty_when_set_to_an_empty_string)
   ASSERT_EQ(terminalpp::extent(0, 0), image.get_preferred_size());
 
   terminalpp::canvas canvas({4, 1});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "      "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(an_image, can_have_its_fill_set)
@@ -166,33 +113,18 @@ TEST(an_image, can_have_its_fill_set)
   image.set_fill('!');
 
   terminalpp::canvas canvas({6, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[4][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[5][0]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'e'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'s'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'t'}, canvas[4][1]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[5][1]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[4][2]);
-  ASSERT_EQ(terminalpp::element{'!'}, canvas[5][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "!!!!!!"_ts,
+          "!test!"_ts,
+          "!!!!!!"_ts,
+          // clang-format on
+      },
+      canvas);
 }

--- a/test/src/image/new_image_test.cpp
+++ b/test/src/image/new_image_test.cpp
@@ -1,7 +1,10 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include <munin/image.hpp>
 #include <munin/render_surface.hpp>
-#include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
+
+using namespace terminalpp::literals;
 
 TEST(a_new_image, has_a_zero_preferred_size)
 {
@@ -17,7 +20,6 @@ TEST(a_new_image_with_a_fill, has_a_zero_preferred_size)
 
 TEST(a_new_image_with_single_line_empty_content, has_a_zero_preferred_size)
 {
-  using namespace terminalpp::literals;
   munin::image image(""_ts);
   ASSERT_EQ(terminalpp::extent(0, 0), image.get_preferred_size());
 }
@@ -26,12 +28,11 @@ TEST(
     a_new_image_with_single_line_content,
     has_a_preferred_size_with_the_width_of_that_line)
 {
-  using namespace terminalpp::literals;
   auto const content = "abcde"_ts;
   munin::image image(content);
 
-  auto const expected_preferred_size =
-      terminalpp::extent{terminalpp::coordinate_type(content.size()), 1};
+  auto const expected_preferred_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(content.size()), 1};
 
   ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
@@ -40,12 +41,11 @@ TEST(
     a_new_image_with_single_line_content_and_a_fill,
     has_a_preferred_size_with_the_width_of_that_line)
 {
-  using namespace terminalpp::literals;
   auto const content = "abcde"_ts;
   munin::image image(content, terminalpp::element('Y'));
 
-  auto const expected_preferred_size =
-      terminalpp::extent{terminalpp::coordinate_type(content.size()), 1};
+  auto const expected_preferred_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(content.size()), 1};
 
   ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
@@ -53,7 +53,6 @@ TEST(
 TEST(a_new_image_with_empty_multi_line_content, has_a_zero_preferred_size)
 {
   munin::image image(std::vector<terminalpp::string>{});
-
   ASSERT_EQ(terminalpp::extent(0, 0), image.get_preferred_size());
 }
 
@@ -61,14 +60,13 @@ TEST(
     a_new_image_with_multi_line_content,
     has_a_preferred_size_with_the_width_of_the_longest_line_and_height_of_the_number_of_lines)
 {
-  using namespace terminalpp::literals;
   auto const content =
       std::vector<terminalpp::string>{"abcde"_ts, "abcdefg"_ts};
 
   munin::image image(content);
 
-  auto const expected_preferred_size =
-      terminalpp::extent{terminalpp::coordinate_type(content[1].size()), 2};
+  auto const expected_preferred_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(content[1].size()), 2};
 
   ASSERT_EQ(expected_preferred_size, image.get_preferred_size());
 }
@@ -77,7 +75,6 @@ TEST(
     a_new_image_with_multi_line_content_and_a_fill,
     has_a_preferred_size_with_the_width_of_the_longest_line_and_height_of_the_number_of_lines)
 {
-  using namespace terminalpp::literals;
   auto const content =
       std::vector<terminalpp::string>{"abcde"_ts, "abcdefg"_ts};
 
@@ -95,26 +92,20 @@ TEST(a_new_image, draws_whitespace_on_the_canvas)
   image.set_size({2, 2});
 
   terminalpp::canvas canvas({3, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "  X"_ts,
+          "  X"_ts,
+          "XXX"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(a_new_image, refuses_focus)
@@ -138,214 +129,120 @@ TEST(a_new_image_with_a_fill, draws_fill_on_the_canvas)
   image.set_size({2, 2});
 
   terminalpp::canvas canvas({3, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'X'}, canvas[2][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "ZZX"_ts,
+          "ZZX"_ts,
+          "XXX"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_new_image_with_a_single_line_content,
     draws_that_content_centred_with_whitespace_background)
 {
-  using namespace terminalpp::literals;
-  terminalpp::string content = "abc"_ts;
-
-  munin::image image(content);
+  munin::image image("abc"_ts);
   image.set_size({5, 3});
 
   terminalpp::canvas canvas({5, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][0]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][1]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "     "_ts,
+          " abc "_ts,
+          "     "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_new_image_with_a_single_line_content_and_fill,
     draws_that_content_centred_with_filled_background)
 {
-  using namespace terminalpp::literals;
-  terminalpp::string content = "abc"_ts;
-
-  munin::image image(content, 'Z');
+  munin::image image("abc"_ts, 'Z');
   image.set_size({5, 3});
 
   terminalpp::canvas canvas({5, 3});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[4][0]);
-
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'c'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[4][1]);
-
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'Z'}, canvas[4][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "ZZZZZ"_ts,
+          "ZabcZ"_ts,
+          "ZZZZZ"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_new_image_with_multi_line_content,
     draws_that_content_centred_with_whitespace_background)
 {
-  using namespace terminalpp::literals;
-  std::vector<terminalpp::string> content = {"ab"_ts, "d"_ts, "efg"_ts};
-
-  munin::image image(content);
+  munin::image image({"ab"_ts, "d"_ts, "efg"_ts});
   image.set_size({5, 5});
 
   terminalpp::canvas canvas({5, 5});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][0]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][1]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][2]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'e'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'f'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'g'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][3]);
-
-  ASSERT_EQ(terminalpp::element{' '}, canvas[0][4]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[1][4]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[2][4]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[3][4]);
-  ASSERT_EQ(terminalpp::element{' '}, canvas[4][4]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "     "_ts,
+          " ab  "_ts,
+          " d   "_ts,
+          " efg "_ts,
+          "     "_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(
     a_new_image_with_multi_line_content_with_fill,
     draws_that_content_centred_with_fill_background)
 {
-  using namespace terminalpp::literals;
-  std::vector<terminalpp::string> content = {"ab"_ts, "d"_ts, "efg"_ts};
-
-  munin::image image(content, 'T');
+  munin::image image({"ab"_ts, "d"_ts, "efg"_ts}, 'T');
   image.set_size({5, 5});
 
   terminalpp::canvas canvas({5, 5});
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   munin::render_surface surface{canvas};
   image.draw(surface, {{}, image.get_size()});
 
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[0][0]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[1][0]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[2][0]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[3][0]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[4][0]);
-
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'a'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'b'}, canvas[2][1]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[3][1]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[4][1]);
-
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'d'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[2][2]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[3][2]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[4][2]);
-
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[0][3]);
-  ASSERT_EQ(terminalpp::element{'e'}, canvas[1][3]);
-  ASSERT_EQ(terminalpp::element{'f'}, canvas[2][3]);
-  ASSERT_EQ(terminalpp::element{'g'}, canvas[3][3]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[4][3]);
-
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[0][4]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[1][4]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[2][4]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[3][4]);
-  ASSERT_EQ(terminalpp::element{'T'}, canvas[4][4]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "TTTTT"_ts,
+          "TabTT"_ts,
+          "TdTTT"_ts,
+          "TefgT"_ts,
+          "TTTTT"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(make_image_with_no_content, makes_a_new_default_image)
@@ -364,7 +261,6 @@ TEST(make_image_with_no_content_and_fill, makes_a_new_default_image_with_fill)
 
 TEST(make_image_with_a_string_content, makes_a_single_line_image)
 {
-  using namespace terminalpp::literals;
   auto const content = "test"_ts;
   std::shared_ptr<munin::image> image = munin::make_image(content);
 
@@ -375,7 +271,6 @@ TEST(
     make_image_with_a_string_content_and_fill,
     makes_a_single_line_image_with_fill)
 {
-  using namespace terminalpp::literals;
   auto const content = "test"_ts;
   auto const fill = terminalpp::element('z');
   std::shared_ptr<munin::image> image = munin::make_image(content, fill);
@@ -386,7 +281,6 @@ TEST(
 TEST(make_image_with_a_vector_content, makes_a_multi_line_image)
 {
   std::vector<terminalpp::string> const content = {"ab", "cd"};
-
   std::shared_ptr<munin::image> image = munin::make_image(content);
   ASSERT_EQ(image->to_json(), munin::image(content).to_json());
 }
@@ -397,7 +291,6 @@ TEST(
 {
   std::vector<terminalpp::string> const content = {"ab", "cd"};
   auto const fill = terminalpp::element('Q');
-
   std::shared_ptr<munin::image> image = munin::make_image(content, fill);
   ASSERT_EQ(image->to_json(), munin::image(content, fill).to_json());
 }

--- a/test/src/scroll_pane/scroll_pane_test.cpp
+++ b/test/src/scroll_pane/scroll_pane_test.cpp
@@ -1,3 +1,5 @@
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include "mock/component.hpp"
 #include <munin/detail/unicode_glyphs.hpp>
 #include <munin/render_surface.hpp>
@@ -5,11 +7,11 @@
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <gtest/gtest.h>
 
-using testing::_;
+using namespace terminalpp::literals;  // NOLINT
+using testing::_;                      // NOLINT
 using testing::Return;
 using testing::ReturnPointee;
 using testing::SaveArg;
-using namespace terminalpp::literals;
 
 namespace {
 
@@ -65,49 +67,49 @@ class a_new_scroll_pane : public testing::Test
 TEST_F(a_new_scroll_pane, draws_the_component_within_its_frame)
 {
   terminalpp::canvas canvas({4, 4});
-  munin::render_surface surface{canvas};
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   scroll_pane->set_size({4, 4});
+
+  munin::render_surface surface{canvas};
   scroll_pane->draw(surface, {{0, 0}, {4, 4}});
 
-  ASSERT_EQ(munin::detail::single_lined_rounded_top_left_corner, canvas[0][0]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(munin::detail::single_lined_rounded_top_right_corner, canvas[3][0]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'0'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'1'}, canvas[2][1]);
-  ASSERT_EQ(munin::detail::single_lined_cross, canvas[3][1]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'1'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'2'}, canvas[2][2]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[3][2]);
-  ASSERT_EQ(
-      munin::detail::single_lined_rounded_bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(munin::detail::single_lined_cross, canvas[1][3]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[2][3]);
-  ASSERT_EQ(
-      munin::detail::single_lined_rounded_bottom_right_corner, canvas[3][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            munin::detail::single_lined_rounded_top_left_corner,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_rounded_top_right_corner,
+          },
+          {
+            munin::detail::single_lined_vertical_beam,
+            '0',
+            '1',
+            munin::detail::single_lined_cross,
+          },
+          {
+            munin::detail::single_lined_vertical_beam,
+            '1',
+            '2',
+            munin::detail::single_lined_vertical_beam,
+          },
+          {
+            munin::detail::single_lined_rounded_bottom_left_corner,
+            munin::detail::single_lined_cross,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_rounded_bottom_right_corner,
+          },
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST_F(a_new_scroll_pane, tracks_the_cursor_in_the_inner_component)
 {
   terminalpp::canvas canvas({4, 4});
-  munin::render_surface surface{canvas};
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   scroll_pane->set_size({4, 4});
 
@@ -115,26 +117,39 @@ TEST_F(a_new_scroll_pane, tracks_the_cursor_in_the_inner_component)
       .WillByDefault(Return(terminalpp::point(9, 9)));
   inner_component_->on_cursor_position_changed();
 
+  munin::render_surface surface{canvas};
   scroll_pane->draw(surface, {{0, 0}, {4, 4}});
 
-  ASSERT_EQ(munin::detail::single_lined_rounded_top_left_corner, canvas[0][0]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(munin::detail::single_lined_rounded_top_right_corner, canvas[3][0]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[0][1]);
-  ASSERT_EQ(terminalpp::element{'6'}, canvas[1][1]);
-  ASSERT_EQ(terminalpp::element{'7'}, canvas[2][1]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[3][1]);
-  ASSERT_EQ(munin::detail::single_lined_vertical_beam, canvas[0][2]);
-  ASSERT_EQ(terminalpp::element{'7'}, canvas[1][2]);
-  ASSERT_EQ(terminalpp::element{'8'}, canvas[2][2]);
-  ASSERT_EQ(munin::detail::single_lined_cross, canvas[3][2]);
-  ASSERT_EQ(
-      munin::detail::single_lined_rounded_bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(munin::detail::single_lined_horizontal_beam, canvas[1][3]);
-  ASSERT_EQ(munin::detail::single_lined_cross, canvas[2][3]);
-  ASSERT_EQ(
-      munin::detail::single_lined_rounded_bottom_right_corner, canvas[3][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            munin::detail::single_lined_rounded_top_left_corner,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_rounded_top_right_corner,
+          },
+          {
+            munin::detail::single_lined_vertical_beam,
+            '6',
+            '7',
+            munin::detail::single_lined_vertical_beam,
+          },
+          {
+            munin::detail::single_lined_vertical_beam,
+            '7',
+            '8',
+            munin::detail::single_lined_cross,
+          },
+          {
+            munin::detail::single_lined_rounded_bottom_left_corner,
+            munin::detail::single_lined_horizontal_beam,
+            munin::detail::single_lined_cross,
+            munin::detail::single_lined_rounded_bottom_right_corner,
+          },
+          // clang-format on
+      },
+      canvas);
 }
 
 namespace {
@@ -178,14 +193,7 @@ TEST_F(
     highlights_the_whole_frame_when_the_underlying_component_receives_focus)
 {
   terminalpp::canvas canvas({4, 4});
-  munin::render_surface surface{canvas};
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   scroll_pane->set_size({4, 4});
   scroll_pane->set_highlight_attribute(highlight_attribute);
@@ -193,24 +201,39 @@ TEST_F(
   ON_CALL(*inner_component_, do_has_focus()).WillByDefault(Return(true));
   inner_component_->on_focus_set();
 
+  munin::render_surface surface{canvas};
   scroll_pane->draw(surface, {{0, 0}, {4, 4}});
 
-  EXPECT_EQ(highlighted_single_lined_rounded_top_left_corner, canvas[0][0]);
-  EXPECT_EQ(highlighted_single_lined_horizontal_beam, canvas[1][0]);
-  EXPECT_EQ(highlighted_single_lined_horizontal_beam, canvas[2][0]);
-  EXPECT_EQ(highlighted_single_lined_rounded_top_right_corner, canvas[3][0]);
-  EXPECT_EQ(highlighted_single_lined_vertical_beam, canvas[0][1]);
-  EXPECT_EQ(terminalpp::element{'0'}, canvas[1][1]);
-  EXPECT_EQ(terminalpp::element{'1'}, canvas[2][1]);
-  EXPECT_EQ(highlighted_single_lined_cross, canvas[3][1]);
-  EXPECT_EQ(highlighted_single_lined_vertical_beam, canvas[0][2]);
-  EXPECT_EQ(terminalpp::element{'1'}, canvas[1][2]);
-  EXPECT_EQ(terminalpp::element{'2'}, canvas[2][2]);
-  EXPECT_EQ(highlighted_single_lined_vertical_beam, canvas[3][2]);
-  EXPECT_EQ(highlighted_single_lined_rounded_bottom_left_corner, canvas[0][3]);
-  EXPECT_EQ(highlighted_single_lined_cross, canvas[1][3]);
-  EXPECT_EQ(highlighted_single_lined_horizontal_beam, canvas[2][3]);
-  EXPECT_EQ(highlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            highlighted_single_lined_rounded_top_left_corner,
+            highlighted_single_lined_horizontal_beam,
+            highlighted_single_lined_horizontal_beam,
+            highlighted_single_lined_rounded_top_right_corner,
+          },
+          {
+            highlighted_single_lined_vertical_beam,
+            '0',
+            '1',
+            highlighted_single_lined_cross,
+          },
+          {
+            highlighted_single_lined_vertical_beam,
+            '1',
+            '2',
+            highlighted_single_lined_vertical_beam,
+          },
+          {
+            highlighted_single_lined_rounded_bottom_left_corner,
+            highlighted_single_lined_cross,
+            highlighted_single_lined_horizontal_beam,
+            highlighted_single_lined_rounded_bottom_right_corner,
+          },
+          // clang-format on
+      },
+      canvas);
 }
 
 namespace {
@@ -254,14 +277,7 @@ TEST_F(
     lowlights_the_whole_frame_when_the_underlying_component_loses_focus)
 {
   terminalpp::canvas canvas({4, 4});
-  munin::render_surface surface{canvas};
-
-  terminalpp::for_each_in_region(
-      canvas,
-      {{}, canvas.size()},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = 'X'; });
+  fill_canvas(canvas, 'X');
 
   scroll_pane->set_size({4, 4});
   scroll_pane->set_highlight_attribute(highlight_attribute);
@@ -273,24 +289,39 @@ TEST_F(
   ON_CALL(*inner_component_, do_has_focus()).WillByDefault(Return(false));
   inner_component_->on_focus_lost();
 
+  munin::render_surface surface{canvas};
   scroll_pane->draw(surface, {{0, 0}, {4, 4}});
 
-  EXPECT_EQ(lowlighted_single_lined_rounded_top_left_corner, canvas[0][0]);
-  EXPECT_EQ(lowlighted_single_lined_horizontal_beam, canvas[1][0]);
-  EXPECT_EQ(lowlighted_single_lined_horizontal_beam, canvas[2][0]);
-  EXPECT_EQ(lowlighted_single_lined_rounded_top_right_corner, canvas[3][0]);
-  EXPECT_EQ(lowlighted_single_lined_vertical_beam, canvas[0][1]);
-  EXPECT_EQ(terminalpp::element{'0'}, canvas[1][1]);
-  EXPECT_EQ(terminalpp::element{'1'}, canvas[2][1]);
-  EXPECT_EQ(lowlighted_single_lined_cross, canvas[3][1]);
-  EXPECT_EQ(lowlighted_single_lined_vertical_beam, canvas[0][2]);
-  EXPECT_EQ(terminalpp::element{'1'}, canvas[1][2]);
-  EXPECT_EQ(terminalpp::element{'2'}, canvas[2][2]);
-  EXPECT_EQ(lowlighted_single_lined_vertical_beam, canvas[3][2]);
-  EXPECT_EQ(lowlighted_single_lined_rounded_bottom_left_corner, canvas[0][3]);
-  EXPECT_EQ(lowlighted_single_lined_cross, canvas[1][3]);
-  EXPECT_EQ(lowlighted_single_lined_horizontal_beam, canvas[2][3]);
-  EXPECT_EQ(lowlighted_single_lined_rounded_bottom_right_corner, canvas[3][3]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            lowlighted_single_lined_rounded_top_left_corner,
+            lowlighted_single_lined_horizontal_beam,
+            lowlighted_single_lined_horizontal_beam,
+            lowlighted_single_lined_rounded_top_right_corner,
+          },
+          {
+            lowlighted_single_lined_vertical_beam,
+            '0',
+            '1',
+            lowlighted_single_lined_cross,
+          },
+          {
+            lowlighted_single_lined_vertical_beam,
+            '1',
+            '2',
+            lowlighted_single_lined_vertical_beam,
+          },
+          {
+            lowlighted_single_lined_rounded_bottom_left_corner,
+            lowlighted_single_lined_cross,
+            lowlighted_single_lined_horizontal_beam,
+            lowlighted_single_lined_rounded_bottom_right_corner,
+          },
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST(

--- a/test/src/solid_frame/solid_frame_test.cpp
+++ b/test/src/solid_frame/solid_frame_test.cpp
@@ -1,31 +1,107 @@
 #include "solid_frame_test.hpp"
+#include "assert_similar.hpp"
+#include "fill_canvas.hpp"
 #include "mock/component.hpp"
 #include "redraw.hpp"
+#include <terminalpp/attribute.hpp>
 #include <terminalpp/string.hpp>
 
+using namespace terminalpp::literals;  // NOLINT
 using testing::Return;
 
-using namespace terminalpp::literals;
-
 namespace {
-terminalpp::glyph const top_left_corner = '+';
-terminalpp::glyph const top_right_corner = '+';
-terminalpp::glyph const bottom_left_corner = '+';
-terminalpp::glyph const bottom_right_corner = '+';
-terminalpp::glyph const horizontal_beam = '-';
-terminalpp::glyph const vertical_beam = '|';
 
-terminalpp::glyph const unicode_top_left_corner = u8"\\U256D"_ets[0].glyph_;
-terminalpp::glyph const unicode_top_right_corner = u8"\\U256E"_ets[0].glyph_;
-terminalpp::glyph const unicode_bottom_left_corner = u8"\\U2570"_ets[0].glyph_;
-terminalpp::glyph const unicode_bottom_right_corner = u8"\\U256F"_ets[0].glyph_;
-terminalpp::glyph const unicode_horizontal_beam = u8"\\U2500"_ets[0].glyph_;
-terminalpp::glyph const unicode_vertical_beam = u8"\\U2502"_ets[0].glyph_;
-
-auto const highlight_attribute = terminalpp::attribute(
+constexpr auto highlight_attribute = terminalpp::attribute(
     terminalpp::graphics::colour::cyan,
     terminalpp::colour(),
     terminalpp::graphics::intensity::bold);
+
+void assert_ansi_frame_with_attribute(
+    terminalpp::canvas &canvas,
+    terminalpp::attribute const &attr = terminalpp::attribute{})
+{
+  static auto const top_left_corner = R"(+)"_ete.glyph_;
+  static auto const top_right_corner = R"(+)"_ete.glyph_;
+  static auto const bottom_left_corner = R"(+)"_ete.glyph_;
+  static auto const bottom_right_corner = R"(+)"_ete.glyph_;
+  static auto const horizontal_beam = R"(-)"_ete.glyph_;
+  static auto const vertical_beam = R"(|)"_ete.glyph_;
+
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            { top_left_corner, attr },
+            { horizontal_beam, attr },
+            { horizontal_beam, attr },
+            { top_right_corner, attr },
+          },
+          {
+            { vertical_beam, attr },
+            'X',
+            'X',
+            { vertical_beam, attr },
+          },
+          {
+            { vertical_beam, attr },
+            'X',
+            'X',
+            { vertical_beam, attr },
+          },
+          {
+            { bottom_left_corner, attr },
+            { horizontal_beam, attr },
+            { horizontal_beam, attr },
+            { bottom_right_corner, attr },
+          },
+          // clang-format on
+      },
+      canvas);
+}
+
+void assert_unicode_frame_with_attribute(
+    terminalpp::canvas &canvas,
+    terminalpp::attribute const &attr = terminalpp::attribute{})
+{
+  static auto const top_left_corner = R"(\U256D)"_ete.glyph_;
+  static auto const top_right_corner = R"(\U256E)"_ete.glyph_;
+  static auto const bottom_left_corner = R"(\U2570)"_ete.glyph_;
+  static auto const bottom_right_corner = R"(\U256F)"_ete.glyph_;
+  static auto const horizontal_beam = R"(\U2500)"_ete.glyph_;
+  static auto const vertical_beam = R"(\U2502)"_ete.glyph_;
+
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          {
+            { top_left_corner, attr },
+            { horizontal_beam, attr },
+            { horizontal_beam, attr },
+            { top_right_corner, attr },
+          },
+          {
+            { vertical_beam, attr },
+            'X',
+            'X',
+            { vertical_beam, attr },
+          },
+          {
+            { vertical_beam, attr },
+            'X',
+            'X',
+            { vertical_beam, attr },
+          },
+          {
+            { bottom_left_corner, attr },
+            { horizontal_beam, attr },
+            { horizontal_beam, attr },
+            { bottom_right_corner, attr },
+          },
+          // clang-format on
+      },
+      canvas);
+}
+
 }  // namespace
 
 TEST_F(a_solid_frame, is_a_component)
@@ -38,21 +114,12 @@ TEST_F(a_solid_frame_with_no_unicode_support, draws_a_border)
   frame_.set_size({4, 4});
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(top_left_corner, canvas[0][0]);
-  ASSERT_EQ(horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(top_right_corner, canvas[3][0]);
-  ASSERT_EQ(vertical_beam, canvas[0][1]);
-  ASSERT_EQ(vertical_beam, canvas[3][1]);
-  ASSERT_EQ(vertical_beam, canvas[0][2]);
-  ASSERT_EQ(vertical_beam, canvas[3][2]);
-  ASSERT_EQ(bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(horizontal_beam, canvas[1][3]);
-  ASSERT_EQ(horizontal_beam, canvas[2][3]);
-  ASSERT_EQ(bottom_right_corner, canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas);
 }
 
 TEST_F(
@@ -61,26 +128,17 @@ TEST_F(
   frame_.set_size({4, 4});
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(unicode_top_left_corner, canvas[0][0]);
-  ASSERT_EQ(unicode_horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(unicode_horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(unicode_top_right_corner, canvas[3][0]);
-  ASSERT_EQ(unicode_vertical_beam, canvas[0][1]);
-  ASSERT_EQ(unicode_vertical_beam, canvas[0][2]);
-  ASSERT_EQ(unicode_vertical_beam, canvas[3][2]);
-  ASSERT_EQ(unicode_vertical_beam, canvas[3][1]);
-  ASSERT_EQ(unicode_bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(unicode_horizontal_beam, canvas[1][3]);
-  ASSERT_EQ(unicode_horizontal_beam, canvas[2][3]);
-  ASSERT_EQ(unicode_bottom_right_corner, canvas[3][3]);
+  assert_unicode_frame_with_attribute(canvas);
 }
 
 TEST_F(a_solid_frame, can_be_displayed_with_a_custom_lowlight)
 {
-  static auto const lowlight_attribute = terminalpp::attribute(
+  static constexpr auto lowlight_attribute = terminalpp::attribute(
       terminalpp::graphics::colour::green,
       terminalpp::colour(),
       terminalpp::graphics::intensity::bold);
@@ -89,21 +147,12 @@ TEST_F(a_solid_frame, can_be_displayed_with_a_custom_lowlight)
   frame_.set_lowlight_attribute(lowlight_attribute);
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[0][0]);
-  ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[1][0]);
-  ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[2][0]);
-  ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[3][0]);
-  ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[3][1]);
-  ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[0][2]);
-  ASSERT_EQ(terminalpp::element('|', lowlight_attribute), canvas[3][2]);
-  ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[0][3]);
-  ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[1][3]);
-  ASSERT_EQ(terminalpp::element('-', lowlight_attribute), canvas[2][3]);
-  ASSERT_EQ(terminalpp::element('+', lowlight_attribute), canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas, lowlight_attribute);
 }
 
 class a_solid_frame_with_an_associated_unfocussed_component
@@ -140,21 +189,12 @@ TEST_F(
   frame_.set_size({4, 4});
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(top_left_corner, canvas[0][0]);
-  ASSERT_EQ(horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(top_right_corner, canvas[3][0]);
-  ASSERT_EQ(vertical_beam, canvas[0][1]);
-  ASSERT_EQ(vertical_beam, canvas[3][1]);
-  ASSERT_EQ(vertical_beam, canvas[0][2]);
-  ASSERT_EQ(vertical_beam, canvas[3][2]);
-  ASSERT_EQ(bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(horizontal_beam, canvas[1][3]);
-  ASSERT_EQ(horizontal_beam, canvas[2][3]);
-  ASSERT_EQ(bottom_right_corner, canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas);
 }
 
 TEST_F(
@@ -167,35 +207,12 @@ TEST_F(
   comp_->on_focus_set();
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(
-      terminalpp::element(top_left_corner, highlight_attribute), canvas[0][0]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, highlight_attribute), canvas[1][0]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, highlight_attribute), canvas[2][0]);
-  ASSERT_EQ(
-      terminalpp::element(top_right_corner, highlight_attribute), canvas[3][0]);
-  ASSERT_EQ(
-      terminalpp::element(vertical_beam, highlight_attribute), canvas[3][2]);
-  ASSERT_EQ(
-      terminalpp::element(vertical_beam, highlight_attribute), canvas[0][1]);
-  ASSERT_EQ(
-      terminalpp::element(vertical_beam, highlight_attribute), canvas[3][1]);
-  ASSERT_EQ(
-      terminalpp::element(vertical_beam, highlight_attribute), canvas[0][2]);
-  ASSERT_EQ(
-      terminalpp::element(bottom_left_corner, highlight_attribute),
-      canvas[0][3]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, highlight_attribute), canvas[1][3]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, highlight_attribute), canvas[2][3]);
-  ASSERT_EQ(
-      terminalpp::element(bottom_right_corner, highlight_attribute),
-      canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas, highlight_attribute);
 }
 
 TEST_F(
@@ -206,12 +223,7 @@ TEST_F(
 
   int redraw_count = 0;
   std::vector<terminalpp::rectangle> redraw_regions;
-  frame_.on_redraw.connect(
-      [&redraw_count, &redraw_regions](auto const &regions)
-      {
-        ++redraw_count;
-        redraw_regions = regions;
-      });
+  frame_.on_redraw.connect(append_regions_to_container(redraw_regions));
 
   ON_CALL(*comp_, do_has_focus()).WillByDefault(Return(true));
   comp_->on_focus_set();
@@ -222,7 +234,6 @@ TEST_F(
       terminalpp::rectangle{{3, 0}, {1, 4}},
       terminalpp::rectangle{{0, 3}, {4, 1}}};
 
-  ASSERT_EQ(1, redraw_count);
   assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 }
 
@@ -232,14 +243,8 @@ TEST_F(
 {
   frame_.set_size({1, 1});
 
-  int redraw_count = 0;
   std::vector<terminalpp::rectangle> redraw_regions;
-  frame_.on_redraw.connect(
-      [&redraw_count, &redraw_regions](auto const &regions)
-      {
-        ++redraw_count;
-        redraw_regions = regions;
-      });
+  frame_.on_redraw.connect(append_regions_to_container(redraw_regions));
 
   ON_CALL(*comp_, do_has_focus()).WillByDefault(Return(true));
   comp_->on_focus_set();
@@ -248,7 +253,6 @@ TEST_F(
       terminalpp::rectangle{{0, 0}, {1, 1}},
   };
 
-  ASSERT_EQ(1, redraw_count);
   assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 
   for (auto region : redraw_regions)
@@ -270,28 +274,19 @@ TEST_F(
   comp_->on_focus_lost();
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(top_left_corner, canvas[0][0]);
-  ASSERT_EQ(horizontal_beam, canvas[1][0]);
-  ASSERT_EQ(horizontal_beam, canvas[2][0]);
-  ASSERT_EQ(top_right_corner, canvas[3][0]);
-  ASSERT_EQ(vertical_beam, canvas[0][1]);
-  ASSERT_EQ(vertical_beam, canvas[3][1]);
-  ASSERT_EQ(vertical_beam, canvas[0][2]);
-  ASSERT_EQ(vertical_beam, canvas[3][2]);
-  ASSERT_EQ(bottom_left_corner, canvas[0][3]);
-  ASSERT_EQ(horizontal_beam, canvas[1][3]);
-  ASSERT_EQ(horizontal_beam, canvas[2][3]);
-  ASSERT_EQ(bottom_right_corner, canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas);
 }
 
 TEST_F(
     a_solid_frame_with_an_associated_focussed_component,
     can_have_a_custom_highlight)
 {
-  terminalpp::attribute custom_highlight = {
+  static constexpr auto custom_highlight = terminalpp::attribute{
       terminalpp::graphics::colour::green,
       terminalpp::graphics::colour::magenta};
 
@@ -302,29 +297,12 @@ TEST_F(
   comp_->on_focus_set();
 
   terminalpp::canvas canvas({4, 4});
+  fill_canvas(canvas, 'X');
+
   munin::render_surface surface{canvas, surface_capabilities_};
   frame_.draw(surface, {{}, {4, 4}});
 
-  ASSERT_EQ(
-      terminalpp::element(top_left_corner, custom_highlight), canvas[0][0]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, custom_highlight), canvas[1][0]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, custom_highlight), canvas[2][0]);
-  ASSERT_EQ(
-      terminalpp::element(top_right_corner, custom_highlight), canvas[3][0]);
-  ASSERT_EQ(terminalpp::element(vertical_beam, custom_highlight), canvas[3][2]);
-  ASSERT_EQ(terminalpp::element(vertical_beam, custom_highlight), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element(vertical_beam, custom_highlight), canvas[3][1]);
-  ASSERT_EQ(terminalpp::element(vertical_beam, custom_highlight), canvas[0][2]);
-  ASSERT_EQ(
-      terminalpp::element(bottom_left_corner, custom_highlight), canvas[0][3]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, custom_highlight), canvas[1][3]);
-  ASSERT_EQ(
-      terminalpp::element(horizontal_beam, custom_highlight), canvas[2][3]);
-  ASSERT_EQ(
-      terminalpp::element(bottom_right_corner, custom_highlight), canvas[3][3]);
+  assert_ansi_frame_with_attribute(canvas, custom_highlight);
 }
 
 TEST_F(
@@ -333,14 +311,8 @@ TEST_F(
 {
   frame_.set_size({4, 4});
 
-  int redraw_count = 0;
   std::vector<terminalpp::rectangle> redraw_regions;
-  frame_.on_redraw.connect(
-      [&redraw_count, &redraw_regions](auto const &regions)
-      {
-        ++redraw_count;
-        redraw_regions = regions;
-      });
+  frame_.on_redraw.connect(append_regions_to_container(redraw_regions));
 
   ON_CALL(*comp_, do_has_focus()).WillByDefault(Return(false));
   comp_->on_focus_lost();
@@ -351,6 +323,5 @@ TEST_F(
       terminalpp::rectangle{{3, 0}, {1, 4}},
       terminalpp::rectangle{{0, 3}, {4, 1}}};
 
-  ASSERT_EQ(1, redraw_count);
   assert_equivalent_redraw_regions(expected_redraw_regions, redraw_regions);
 }

--- a/test/src/status_bar/status_bar_test.cpp
+++ b/test/src/status_bar/status_bar_test.cpp
@@ -1,10 +1,14 @@
+#include "assert_similar.hpp"
 #include "fill_canvas.hpp"
 #include "mock/animator.hpp"
+#include "redraw.hpp"
 #include <munin/render_surface.hpp>
 #include <munin/status_bar.hpp>
 #include <gtest/gtest.h>
 
-using testing::_;
+using namespace terminalpp::literals;  // NOLINT
+using namespace std::literals;         // NOLINT
+using testing::_;                      // NOLINT
 using testing::Return;
 
 TEST(a_status_bar, is_a_component)
@@ -41,27 +45,20 @@ TEST_F(a_new_status_bar, draws_itself_as_blank)
   status_bar_->set_size({3, 1});
   status_bar_->draw(surface, {{}, status_bar_->get_size()});
 
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[1][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[2][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas[3][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[4][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[4][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxx"_ts,
+          "x   x"_ts,
+          "xxxxx"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 TEST_F(
     a_new_status_bar, has_a_preferred_size_of_the_message_when_a_message_is_set)
 {
-  using namespace terminalpp::literals;
   static auto const message = "Test!"_ts;
 
   std::optional<terminalpp::extent> preferred_size;
@@ -71,8 +68,8 @@ TEST_F(
 
   status_bar_->set_message(message);
 
-  auto const expected_size =
-      terminalpp::extent{terminalpp::coordinate_type(message.size()), 1};
+  auto const expected_size = terminalpp::extent{
+      static_cast<terminalpp::coordinate_type>(message.size()), 1};
 
   ASSERT_TRUE(preferred_size.has_value());
   ASSERT_EQ(expected_size, *preferred_size);
@@ -80,7 +77,6 @@ TEST_F(
 
 TEST_F(a_new_status_bar, redraws_the_message_when_a_message_is_set)
 {
-  using namespace terminalpp::literals;
   static auto const message = "Test!"_ts;
 
   terminalpp::canvas canvas{{7, 3}};
@@ -92,12 +88,7 @@ TEST_F(a_new_status_bar, redraws_the_message_when_a_message_is_set)
   status_bar_->set_size({5, 1});
 
   std::vector<terminalpp::rectangle> redraw_regions;
-  status_bar_->on_redraw.connect(
-      [&redraw_regions](std::vector<terminalpp::rectangle> const &regions)
-      {
-        redraw_regions.insert(
-            redraw_regions.end(), regions.begin(), regions.end());
-      });
+  status_bar_->on_redraw.connect(append_regions_to_container(redraw_regions));
 
   status_bar_->set_message(message);
 
@@ -106,27 +97,15 @@ TEST_F(a_new_status_bar, redraws_the_message_when_a_message_is_set)
     status_bar_->draw(surface, redraw_region);
   }
 
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[5][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[6][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][1]);
-  ASSERT_EQ(terminalpp::element('T'), canvas[1][1]);
-  ASSERT_EQ(terminalpp::element('e'), canvas[2][1]);
-  ASSERT_EQ(terminalpp::element('s'), canvas[3][1]);
-  ASSERT_EQ(terminalpp::element('t'), canvas[4][1]);
-  ASSERT_EQ(terminalpp::element('!'), canvas[5][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[6][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[4][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[5][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas[6][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxxxx"_ts,
+          "xTest!x"_ts,
+          "xxxxxxx"_ts,
+          // clang-format on
+      },
+      canvas);
 }
 
 namespace {
@@ -134,18 +113,12 @@ namespace {
 class an_animated_status_bar : public testing::Test
 {
  public:
-  an_animated_status_bar() : time_0(std::chrono::steady_clock::now())
+  an_animated_status_bar() : time_0_(std::chrono::steady_clock::now())
   {
-    using namespace terminalpp::literals;
-
-    ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0));
+    ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_));
 
     status_bar_->on_redraw.connect(
-        [this](std::vector<terminalpp::rectangle> const &regions)
-        {
-          redraw_regions_.insert(
-              redraw_regions_.end(), regions.begin(), regions.end());
-        });
+        append_regions_to_container(redraw_regions_));
 
     fill_canvas(canvas_, 'x');
     surface_.offset_by({1, 1});
@@ -155,7 +128,7 @@ class an_animated_status_bar : public testing::Test
     redraw_requested_regions();
   }
 
-  auto number_of_requested_regions() const
+  [[nodiscard]] auto number_of_requested_regions() const
   {
     return redraw_regions_.size();
   }
@@ -175,7 +148,7 @@ class an_animated_status_bar : public testing::Test
   std::shared_ptr<munin::status_bar> status_bar_{
       munin::make_status_bar(*animator_)};
 
-  std::chrono::steady_clock::time_point const time_0;
+  std::chrono::steady_clock::time_point const time_0_;
 
   terminalpp::canvas canvas_{{7, 3}};
   munin::render_surface surface_{canvas_};
@@ -190,138 +163,80 @@ TEST_F(
     an_animated_status_bar,
     less_than_5_seconds_after_drawing_a_message_still_draws_that_message)
 {
-  using namespace std::literals;
-
-  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0 + 5s - 1ms));
+  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_ + 5s - 1ms));
   animator_->redraw_components();
 
   redraw_requested_regions();
 
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][1]);
-  ASSERT_EQ(terminalpp::element('T'), canvas_[1][1]);
-  ASSERT_EQ(terminalpp::element('e'), canvas_[2][1]);
-  ASSERT_EQ(terminalpp::element('s'), canvas_[3][1]);
-  ASSERT_EQ(terminalpp::element('t'), canvas_[4][1]);
-  ASSERT_EQ(terminalpp::element('!'), canvas_[5][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxxxx"_ts,
+          "xTest!x"_ts,
+          "xxxxxxx"_ts,
+          // clang-format on
+      },
+      canvas_);
 }
 
 TEST_F(an_animated_status_bar, after_5_seconds_marquees_two_characters_off)
 {
-  using namespace std::literals;
-
-  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0 + 5s));
+  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_ + 5s));
   animator_->redraw_components();
 
   redraw_requested_regions();
 
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][1]);
-  ASSERT_EQ(terminalpp::element('s'), canvas_[1][1]);
-  ASSERT_EQ(terminalpp::element('t'), canvas_[2][1]);
-  ASSERT_EQ(terminalpp::element('!'), canvas_[3][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[4][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[5][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxxxx"_ts,
+          "xst!  x"_ts,
+          "xxxxxxx"_ts,
+          // clang-format on
+      },
+      canvas_);
 }
 
 TEST_F(an_animated_status_bar, after_5015ms_marquees_four_characters_off)
 {
-  using namespace std::literals;
-
-  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0 + 5015ms));
+  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_ + 5015ms));
   animator_->redraw_components();
 
   redraw_requested_regions();
 
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][1]);
-  ASSERT_EQ(terminalpp::element('!'), canvas_[1][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[2][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[3][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[4][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[5][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxxxx"_ts,
+          "x!    x"_ts,
+          "xxxxxxx"_ts,
+          // clang-format on
+      },
+      canvas_);
 }
 
 TEST_F(an_animated_status_bar, after_5030ms_marquees_all_characters_off)
 {
-  using namespace std::literals;
-
-  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0 + 5030s));
+  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_ + 5030s));
   animator_->redraw_components();
 
   redraw_requested_regions();
 
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][0]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[1][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[2][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[3][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[4][1]);
-  ASSERT_EQ(terminalpp::element(' '), canvas_[5][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][1]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[0][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[1][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[2][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[3][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[4][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[5][2]);
-  ASSERT_EQ(terminalpp::element('x'), canvas_[6][2]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "xxxxxxx"_ts,
+          "x     x"_ts,
+          "xxxxxxx"_ts,
+          // clang-format on
+      },
+      canvas_);
 }
 
 TEST_F(
     an_animated_status_bar,
     after_drawing_all_of_its_animation_frames_does_not_request_a_redraw)
 {
-  using namespace std::literals;
-
   // At time 0, the screen is freshly painted and a delayed function is
   // waiting for execution, but no regions are requested.
   ASSERT_EQ(0, number_of_requested_regions());
@@ -329,7 +244,7 @@ TEST_F(
   // After updating the animation time to after the last frame, the
   // function is executed and there are no more delayed functions, and
   // there are redraw requests awaiting.
-  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0 + 6s));
+  ON_CALL(*animator_, do_now()).WillByDefault(Return(time_0_ + 6s));
   animator_->redraw_components();
 
   ASSERT_GT(number_of_requested_regions(), 0);

--- a/test/src/text_area/text_area_test.cpp
+++ b/test/src/text_area/text_area_test.cpp
@@ -1,5 +1,5 @@
 #include "text_area_test.hpp"
-#include <terminalpp/algorithm/for_each_in_region.hpp>
+#include "fill_canvas.hpp"
 #include <terminalpp/mouse.hpp>
 
 terminalpp::element const a_text_area_base::fill = {'X'};
@@ -7,39 +7,7 @@ terminalpp::element const a_text_area_base::fill = {'X'};
 void a_text_area_base::fill_canvas(terminalpp::extent canvas_size)
 {
   canvas_ = terminalpp::canvas{canvas_size};
-
-  terminalpp::for_each_in_region(
-      canvas_,
-      {{}, canvas_size},
-      [](terminalpp::element &elem,
-         terminalpp::coordinate_type column,
-         terminalpp::coordinate_type row) { elem = a_text_area::fill; });
-}
-
-void a_text_area_base::verify_oob_is_untouched()
-{
-  auto const in_bounds = text_area_.get_size();
-  auto const out_of_bounds = canvas_.size();
-
-  // For now, assume IB and OOB are both based at {0,0}.
-  for (auto oob_y = terminalpp::coordinate_type{0}; oob_y < in_bounds.height_;
-       ++oob_y)
-  {
-    for (auto oob_x = in_bounds.width_; oob_x < out_of_bounds.width_; ++oob_x)
-    {
-      ASSERT_EQ(canvas_[oob_x][oob_y], a_text_area::fill);
-    }
-  }
-
-  for (auto oob_y = in_bounds.height_; oob_y < out_of_bounds.height_; ++oob_y)
-  {
-    for (auto oob_x = terminalpp::coordinate_type{0};
-         oob_x < out_of_bounds.width_;
-         ++oob_x)
-    {
-      ASSERT_EQ(canvas_[oob_x][oob_y], a_text_area::fill);
-    }
-  }
+  ::fill_canvas(canvas_, fill);
 }
 
 TEST_F(a_text_area, is_a_component)

--- a/test/src/text_area/text_area_test.hpp
+++ b/test/src/text_area/text_area_test.hpp
@@ -11,7 +11,6 @@ class a_text_area_base
   terminalpp::canvas canvas_{{0, 0}};
 
   void fill_canvas(terminalpp::extent canvas_size);
-  void verify_oob_is_untouched();
 };
 
 class a_text_area : public a_text_area_base, public testing::Test

--- a/test/src/text_area/text_area_typing_test.cpp
+++ b/test/src/text_area/text_area_typing_test.cpp
@@ -1,10 +1,11 @@
+#include "redraw.hpp"
 #include "text_area_test.hpp"
 #include <munin/render_surface.hpp>
 #include <terminalpp/algorithm/for_each_in_region.hpp>
 #include <terminalpp/canvas.hpp>
 #include <terminalpp/virtual_key.hpp>
 
-using namespace terminalpp::literals;
+using namespace terminalpp::literals;  // NOLINT
 using testing::ValuesIn;
 
 using keypress_test_data = std::tuple<
@@ -27,13 +28,7 @@ class a_text_area_receiving_keypresses
     using std::get;
 
     text_area_.on_redraw.connect(
-        [this](auto const &regions)
-        {
-          for (auto const &region : regions)
-          {
-            text_area_.draw(surface_, region);
-          }
-        });
+        redraw_component_on_surface(text_area_, surface_));
 
     text_area_.on_cursor_position_changed.connect(
         [this] { cursor_position_ = text_area_.get_cursor_position(); });

--- a/test/src/toggle_button/toggle_button_test.cpp
+++ b/test/src/toggle_button/toggle_button_test.cpp
@@ -1,10 +1,13 @@
+#include "gmock/gmock.h"
+#include "redraw.hpp"
 #include <munin/render_surface.hpp>
 #include <munin/toggle_button.hpp>
 #include <terminalpp/canvas.hpp>
 #include <terminalpp/mouse.hpp>
 #include <terminalpp/virtual_key.hpp>
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
+using testing::ElementsAreArray;
 using testing::ValuesIn;
 
 TEST(a_default_constructed_toggle_button, shows_an_unchecked_state)
@@ -127,17 +130,13 @@ TEST(setting_the_toggle_state_of_a_toggle_button, fires_a_redraw_request)
   button->set_size(size);
 
   std::vector<terminalpp::rectangle> redraw_regions;
-  button->on_redraw.connect(
-      [&redraw_regions](std::vector<terminalpp::rectangle> const &regions)
-      {
-        redraw_regions.insert(
-            redraw_regions.end(), regions.begin(), regions.end());
-      });
+  button->on_redraw.connect(append_regions_to_container(redraw_regions));
 
   button->set_toggle_state(true);
 
-  ASSERT_EQ(size_t{1}, redraw_regions.size());
-  ASSERT_EQ(terminalpp::rectangle({1, 1}, {1, 1}), redraw_regions[0]);
+  ASSERT_THAT(
+      redraw_regions,
+      ElementsAreArray({terminalpp::rectangle{{1, 1}, {1, 1}}}));
 }
 
 namespace {
@@ -152,7 +151,7 @@ using event_emission_data = std::tuple<
 class a_toggle_button : public testing::TestWithParam<event_emission_data>
 {
  public:
-  a_toggle_button() : toggle_button_()
+  a_toggle_button()
   {
     toggle_button_.set_size({3, 3});
   }

--- a/test/src/viewport/viewport_redraw_test.cpp
+++ b/test/src/viewport/viewport_redraw_test.cpp
@@ -41,7 +41,7 @@ TEST_P(viewport_cursor_movement_redraw_test, cursor_movements)
   viewport_->on_redraw.connect(
       [&](std::vector<terminalpp::rectangle> const &regions)
       {
-        ASSERT_EQ(1u, regions.size());
+        ASSERT_EQ(1U, regions.size());
         redraw_region = regions[0];
       });
 

--- a/test/src/viewport/viewport_size_test.cpp
+++ b/test/src/viewport/viewport_size_test.cpp
@@ -1,3 +1,4 @@
+#include "assert_similar.hpp"
 #include "fill_canvas.hpp"
 #include "viewport_test.hpp"
 #include <munin/render_surface.hpp>
@@ -7,7 +8,8 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using testing::_;
+using namespace terminalpp::literals;  // NOLINT
+using testing::_;                      // NOLINT
 using testing::Return;
 using testing::ValuesIn;
 
@@ -163,8 +165,12 @@ TEST_F(
   munin::render_surface surface{cvs};
   viewport_->draw(surface, {{}, viewport_->get_size()});
 
-  ASSERT_EQ(terminalpp::element{'g'}, cvs[0][0]);
-  ASSERT_EQ(terminalpp::element{'h'}, cvs[1][0]);
-  ASSERT_EQ(terminalpp::element{'k'}, cvs[0][1]);
-  ASSERT_EQ(terminalpp::element{'l'}, cvs[1][1]);
+  assert_similar_canvas_block(
+      {
+          // clang-format off
+          "gh"_ts,
+          "kl"_ts,
+          // clang-format on
+      },
+      cvs);
 }


### PR DESCRIPTION
* Simplify test cases iterating over specific canvas coordinates, favouring a more declarative approach that looks more like the end result that is expected
* Factor out some common stuff like fill_canvas, draw/store regions on redraw request, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KazDragon/munin/266)
<!-- Reviewable:end -->
